### PR TITLE
Allow SlackClient rtm_connect exceptions to be raised

### DIFF
--- a/slackclient/_client.py
+++ b/slackclient/_client.py
@@ -6,15 +6,17 @@ import json
 from slackclient._server import Server
 
 class SlackClient(object):
-    def __init__(self, token):
+    def __init__(self, token, connect=False):
         self.token = token
-        self.server = Server(self.token, False)
+        self.server = Server(self.token, connect=connect)
 
-    def rtm_connect(self):
+    def rtm_connect(self, debug=False):
         try:
             self.server.rtm_connect()
             return True
         except:
+            if debug:
+                raise
             return False
 
     def api_call(self, method, **kwargs):


### PR DESCRIPTION
The SlackClient method rtm_connect does not provide a reason for
failed connections and only returns True or False. This change
makes it so:
    - Exceptions can be raised in the client's rtm_connect method
    - A connection can be established on instantiation

For example, this exception can now be raised so the problem is not
masked:
    urllib2.HTTPError: HTTP Error 429: Too Many Requests

The slack client can now be instantiated in this manner:
    sc = SlackClient(SLACK_TOKEN, connect=True)

Exceptions can also be raised by invoking rtm_connect as such:
    sc.rtm_connect(debug=True)
