### PR TITLE
Moved coveralls call into after_success in tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,6 @@ exclude= tests/*
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 commands =
     py.test --cov-report= --cov=slackclient {posargs:tests}
-    coveralls
 
 deps =
     -r{toxinidir}/requirements-dev.txt
@@ -28,3 +27,6 @@ deps=flake8
 commands=
     flake8 \
     {toxinidir}/slackclient
+
+after_success =
+    coveralls


### PR DESCRIPTION
#### PR Summary
Moved coveralls call into after_success in tox config

#### Related Issues
Fixes travis/coveralls failure

* ✅  I've read and understood the [Contributing guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* ✅ I've read and agree to the [Code of Conduct](https://github.com/slackapi/python-slackclient/blob/master/CODE_OF_CONDUCT.md).
* ✅ I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* ✅ I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferably).
* ◻️  I've written tests to cover the new code and functionality included in this PR.
* ✅ I've read, agree to, and signed the [Contributor License Agreement (CLA)]