### PR TITLE
Updated RTM user parsing to use a dict instead of a list.

### DIFF
--- a/slackclient/_server.py
+++ b/slackclient/_server.py
@@ -1,7 +1,7 @@
 from slackclient._slackrequest import SlackRequest
 from slackclient._channel import Channel
 from slackclient._user import User
-from slackclient._util import SearchList
+from slackclient._util import SearchList, SearchDict
 from ssl import SSLError
 
 from websocket import create_connection
@@ -20,7 +20,7 @@ class Server(object):
         self.domain = None
         self.login_data = None
         self.websocket = None
-        self.users = SearchList()
+        self.users = SearchDict()
         self.channels = SearchList()
         self.connected = False
         self.ws_url = None
@@ -149,8 +149,7 @@ class Server(object):
             return data.rstrip()
 
     def attach_user(self, name, channel_id, real_name, tz):
-        if self.users.find(channel_id) is None:
-            self.users.append(User(self, name, channel_id, real_name, tz))
+        self.users.update({name: User(self, name, channel_id, real_name, tz)})
 
     def attach_channel(self, name, channel_id, members=None):
         if members is None:

--- a/slackclient/_util.py
+++ b/slackclient/_util.py
@@ -15,3 +15,9 @@ class SearchList(list):
             return items
         else:
             return None
+
+
+class SearchDict(dict):
+
+    def find(self, name):
+        return self.get(name)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -29,7 +29,10 @@ def test_Server_parse_channel_data(server, login_fixture):
 
 def test_Server_parse_user_data(server, login_fixture):
     server.parse_user_data(login_fixture["users"])
-    assert type(server.users.find('fakeuser')) == User
+    fakeuser = server.users.find('fakeuser')
+    assert type(fakeuser) == User
+    assert fakeuser == "fakeuser"
+    assert fakeuser != "someotheruser"
 
 
 def test_Server_cantconnect(server):


### PR DESCRIPTION
#### PR Summary
On some large teams with thousands of users, the `parse_user_data` method in the _server.py was blocking the websocket connection for so long that the websocket URL was expiring before the client attempted to connect to it. I've tested this change on an account with tens of thousands of users, and it doesn't timeout.

#### Related Issues
Fixes #127 

#### Test strategy
Tests didn't need updating, as the result signature was the same, but I added some additional testing to increase coverage.

* ✅ I've read and understood the Contributing guidelines.
* ✅ I've read and agree to the Code of Conduct.
* ✅ I've been mindful about doing atomic commits.
* ✅ I've a descriptive title and added any useful information for the reviewer..
* ✅ I've written tests to cover the new code and functionality included in this PR.
* ✅ I've read, agree to, and signed the Contributor License Agreement.