### PR TITLE
Index users by ID instead of name

### DIFF
--- a/slackclient/_server.py
+++ b/slackclient/_server.py
@@ -148,8 +148,8 @@ class Server(object):
                 raise
             return data.rstrip()
 
-    def attach_user(self, name, channel_id, real_name, tz):
-        self.users.update({name: User(self, name, channel_id, real_name, tz)})
+    def attach_user(self, name, user_id, real_name, tz):
+        self.users.update({user_id: User(self, name, user_id, real_name, tz)})
 
     def attach_channel(self, name, channel_id, members=None):
         if members is None:

--- a/slackclient/_util.py
+++ b/slackclient/_util.py
@@ -25,6 +25,6 @@ class SearchDict(dict):
             return user
         else:
             # If the user can't be found by name, try searching by ID
-            for name, user in self.items():
-                if str(user.id) == search_string:
+            for id, user in self.items():
+                if str(user.name) == search_string:
                     return user

--- a/slackclient/_util.py
+++ b/slackclient/_util.py
@@ -19,12 +19,12 @@ class SearchList(list):
 
 class SearchDict(dict):
     def find(self, search_string):
-        # Find the user by name
+        # Find the user by ID
         user = self.get(search_string)
         if user:
             return user
         else:
-            # If the user can't be found by name, try searching by ID
+            # If the user can't be found by ID, try searching by name
             for id, user in self.items():
                 if str(user.name) == search_string:
                     return user


### PR DESCRIPTION
#### PR Summary
> Since it's more common to search for users by ID, index the dictionary by user ID instead of name.
> Also fixed a typo where `user_id` was `channel_id`

#### Test strategy
> No additional tests needed


✅ I've read and understood the [Contributing guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
✅ I've read and agree to the [Code of Conduct](https://github.com/slackapi/python-slackclient/blob/master/CODE_OF_CONDUCT.md).
✅ I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
✅ I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferably).
✅ I've written tests to cover the new code and functionality included in this PR.
✅ I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).
