### PR TITLE
Add user-agent headers to HTTP requests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,31 @@
-from setuptools import setup
+from setuptools import setup, find_packages
+
+from setuptools import setup, find_packages
+import codecs
+import os
+import re
+
+here = os.path.abspath(os.path.dirname(__file__))
+
+# Read the version number from a source file.
+# Why read it, and not import?
+# see https://groups.google.com/d/topic/pypa-dev/0PkjVpcxTzQ/discussion
+def find_version(*file_paths):
+    # Open in Latin-1 so that we avoid encoding errors.
+    # Use codecs.open for Python 2 compatibility
+    with codecs.open(os.path.join(here, *file_paths), 'r', 'latin1') as f:
+        version_file = f.read()
+
+    # The version line must have the form
+    # __version__ = 'ver'
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
 
 setup(name='slackclient',
-      version='1.0.4',
+      version=find_version('slackclient', 'version.py'),
       description='Python client for Slack.com',
       url='http://github.com/slackapi/python-slackclient',
       author='Ryan Huber',

--- a/slackclient/_slackrequest.py
+++ b/slackclient/_slackrequest.py
@@ -3,6 +3,9 @@ import json
 import requests
 import six
 
+import sys
+import platform
+from .version import __version__
 
 class SlackRequest(object):
 
@@ -19,11 +22,22 @@ class SlackRequest(object):
             domain (str): if for some reason you want to send your request to something other
                 than slack.com
         '''
-        post_data = post_data or {}
+
+        user_agent = [] # Construct the user-agent header with the package info, Python version and OS version.
+
+        client_name = __name__.split('.')[0] # __name__ returns 'slackclient._slackrequest', we only want 'slackclient'
+        client_version = __version__ # Version is returned from version.py
+
+        user_agent.append("%s/%s" % (client_name, client_version))
+        user_agent.append("python/%s.%s.%s" % (sys.version_info[0], sys.version_info[1], sys.version_info[2]))
+        user_agent.append("%s/%s" % (platform.system(), platform.release()))
+
+        headers = {'user-agent': ' '.join(map(str, user_agent))}
 
         # Pull file out so it isn't JSON encoded like normal fields.
         # Only do this for requests that are UPLOADING files; downloading files
         # use the 'file' argument to point to a File ID.
+        post_data = post_data or {}
         upload_requests = ['files.upload']
         files = None
         if request in upload_requests:
@@ -36,4 +50,4 @@ class SlackRequest(object):
         url = 'https://{0}/api/{1}'.format(domain, request)
         post_data['token'] = token
 
-        return requests.post(url, data=post_data, files=files)
+        return requests.post(url, headers=headers, data=post_data, files=files)

--- a/slackclient/version.py
+++ b/slackclient/version.py
@@ -1,0 +1,2 @@
+# see: http://legacy.python.org/dev/peps/pep-0440/#public-version-identifiers
+__version__ = '1.0.4'

--- a/tests/test_slackrequest.py
+++ b/tests/test_slackrequest.py
@@ -2,6 +2,14 @@ from slackclient._slackrequest import SlackRequest
 import json
 import os
 
+def test_post_headers(mocker):
+    requests = mocker.patch('slackclient._slackrequest.requests')
+    SlackRequest.do('xoxb-123', 'chat.postMessage', {'text': 'test', 'channel': '#general'})
+
+    args, kwargs = requests.post.call_args
+    assert None != kwargs['headers']['user-agent']
+    assert "slackclient" in kwargs['headers']['user-agent']
+
 def test_post_file(mocker):
     requests = mocker.patch('slackclient._slackrequest.requests')
 


### PR DESCRIPTION
#### PR Summary
> Adds user-agent headers to HTTP requests

#### Test strategy
> Added tests to `test_slackrequest.py`

✅ I've read and understood the [Contributing guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
✅ I've read and agree to the [Code of Conduct](https://github.com/slackapi/python-slackclient/blob/master/CODE_OF_CONDUCT.md).
✅ I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
✅ I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferably).
✅ I've written tests to cover the new code and functionality included in this PR.
✅ I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).