### PR TITLE
Add user-agent headers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,31 @@
-from setuptools import setup
+from setuptools import setup, find_packages
+
+from setuptools import setup, find_packages
+import codecs
+import os
+import re
+
+here = os.path.abspath(os.path.dirname(__file__))
+
+# Read the version number from a source file.
+# Why read it, and not import?
+# see https://groups.google.com/d/topic/pypa-dev/0PkjVpcxTzQ/discussion
+def find_version(*file_paths):
+    # Open in Latin-1 so that we avoid encoding errors.
+    # Use codecs.open for Python 2 compatibility
+    with codecs.open(os.path.join(here, *file_paths), 'r', 'latin1') as f:
+        version_file = f.read()
+
+    # The version line must have the form
+    # __version__ = 'ver'
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
 
 setup(name='slackclient',
-      version='1.0.4',
+      version=find_version('slackclient', 'version.py'),
       description='Python client for Slack.com',
       url='http://github.com/slackapi/python-slackclient',
       author='Ryan Huber',

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,4 @@
-from setuptools import setup, find_packages
-
-from setuptools import setup, find_packages
+from setuptools import setup
 import codecs
 import os
 import re

--- a/slackclient/_client.py
+++ b/slackclient/_client.py
@@ -27,9 +27,6 @@ class SlackClient(object):
         self.token = token
         self.server = Server(self.token, False)
 
-    def get_user_agent(self):
-        return self.server.get_user_agent()
-
     def append_user_agent(self, name, version):
         self.server.append_user_agent(name, version)
 

--- a/slackclient/_client.py
+++ b/slackclient/_client.py
@@ -27,6 +27,12 @@ class SlackClient(object):
         self.token = token
         self.server = Server(self.token, False)
 
+    def get_user_agent(self):
+        return self.server.get_user_agent()
+
+    def append_user_agent(self, name, version):
+        self.server.append_user_agent(name, version)
+
     def rtm_connect(self):
         '''
         Connects to the RTM Websocket

--- a/slackclient/_server.py
+++ b/slackclient/_server.py
@@ -61,6 +61,12 @@ class Server(object):
     def __repr__(self):
         return self.__str__()
 
+    def get_user_agent(self):
+        return self.api_requester.get_user_agent()
+
+    def append_user_agent(self, name, version):
+        self.api_requester.append_user_agent(name, version)
+
     def rtm_connect(self, reconnect=False):
         reply = self.api_requester.do(self.token, "rtm.start")
         if reply.status_code != 200:

--- a/slackclient/_server.py
+++ b/slackclient/_server.py
@@ -61,9 +61,6 @@ class Server(object):
     def __repr__(self):
         return self.__str__()
 
-    def get_user_agent(self):
-        return self.api_requester.get_user_agent()
-
     def append_user_agent(self, name, version):
         self.api_requester.append_user_agent(name, version)
 

--- a/slackclient/_slackrequest.py
+++ b/slackclient/_slackrequest.py
@@ -3,6 +3,9 @@ import json
 import requests
 import six
 
+import sys
+import platform
+from .version import __version__
 
 class SlackRequest(object):
 
@@ -19,11 +22,22 @@ class SlackRequest(object):
             domain (str): if for some reason you want to send your request to something other
                 than slack.com
         '''
-        post_data = post_data or {}
+
+        user_agent = [] # Construct the user-agent header with the package info, Python version and OS version.
+
+        client_name = __name__.split('.')[0] # __name__ returns 'slackclient._slackrequest', we only want 'slackclient'
+        client_version = __version__ # Version is returned from version.py
+
+        user_agent.append("%s/%s" % (client_name, client_version))
+        user_agent.append("python/%s.%s.%s" % (sys.version_info[0], sys.version_info[1], sys.version_info[2]))
+        user_agent.append("%s/%s" % (platform.system(), platform.release()))
+
+        headers = {'user-agent': ' '.join(map(str, user_agent))}
 
         # Pull file out so it isn't JSON encoded like normal fields.
         # Only do this for requests that are UPLOADING files; downloading files
         # use the 'file' argument to point to a File ID.
+        post_data = post_data or {}
         upload_requests = ['files.upload']
         files = None
         if request in upload_requests:
@@ -36,4 +50,4 @@ class SlackRequest(object):
         url = 'https://{0}/api/{1}'.format(domain, request)
         post_data['token'] = token
 
-        return requests.post(url, data=post_data, files=files)
+        return requests.post(url, headers=headers, data=post_data, files=files)

--- a/slackclient/_slackrequest.py
+++ b/slackclient/_slackrequest.py
@@ -7,22 +7,32 @@ import sys
 import platform
 from .version import __version__
 
+
 class SlackRequest(object):
     def __init__(self):
-        client_name = __name__.split('.')[0]  # __name__ returns 'slackclient._slackrequest', we only want 'slackclient'
+
+        # __name__ returns 'slackclient._slackrequest', we only want 'slackclient'
+        client_name = __name__.split('.')[0]
         client_version = __version__  # Version is returned from version.py
 
         # Construct the user-agent header with the package info, Python version and OS version.
-        self.default_user_agent = {"client": "{0}/{1}".format(client_name, client_version),
-                      "python": "Python/{0}.{1}.{2}".format(sys.version_info[0], sys.version_info[1], sys.version_info[2]),
-                      "system": "{0}/{1}".format(platform.system(), platform.release())}
+        self.default_user_agent = {
+            "client": "{0}/{1}".format(client_name, client_version),
+            "python": "Python/{0}.{1}.{2}".format(
+                sys.version_info[0],
+                sys.version_info[1],
+                sys.version_info[2]
+            ),
+            "system": "{0}/{1}".format(platform.system(), platform.release())
+        }
 
         self.custom_user_agent = None
 
     def get_user_agent(self):
         # Check for custom user-agent and append if found
         if self.custom_user_agent:
-            custom_ua_string = " ".join([ "/".join(client_info) for client_info in self.custom_user_agent])
+            custom_ua_list = ["/".join(client_info) for client_info in self.custom_user_agent]
+            custom_ua_string = " ".join(custom_ua_list)
             self.default_user_agent['custom'] = custom_ua_string
 
         # Concatenate and format the user-agent string to be passed into request headers
@@ -39,7 +49,7 @@ class SlackRequest(object):
         if self.custom_user_agent:
             self.custom_user_agent.append([name, version])
         else:
-            self.custom_user_agent = [ [name, version] ]
+            self.custom_user_agent = [[name, version]]
 
     def do(self, token, request="?", post_data=None, domain="slack.com"):
         """

--- a/slackclient/_slackrequest.py
+++ b/slackclient/_slackrequest.py
@@ -18,11 +18,7 @@ class SlackRequest(object):
         # Construct the user-agent header with the package info, Python version and OS version.
         self.default_user_agent = {
             "client": "{0}/{1}".format(client_name, client_version),
-            "python": "Python/{0}.{1}.{2}".format(
-                sys.version_info[0],
-                sys.version_info[1],
-                sys.version_info[2]
-            ),
+            "python": "Python/{v.major}.{v.minor}.{v.micro}".format(v=sys.version_info),
             "system": "{0}/{1}".format(platform.system(), platform.release())
         }
 
@@ -44,10 +40,8 @@ class SlackRequest(object):
         return user_agent_string
 
     def append_user_agent(self, name, version):
-        name = str.replace(name, "/", ":")
-        version = str.replace(version, "/", ":")
         if self.custom_user_agent:
-            self.custom_user_agent.append([name, version])
+            self.custom_user_agent.append([name.replace("/", ":"), version.replace("/", ":")])
         else:
             self.custom_user_agent = [[name, version]]
 

--- a/slackclient/_slackrequest.py
+++ b/slackclient/_slackrequest.py
@@ -46,7 +46,7 @@ class SlackRequest(object):
             self.custom_user_agent = [[name, version]]
 
     def do(self, token, request="?", post_data=None, domain="slack.com", timeout=None):
-        '''
+        """
         Perform a POST request to the Slack Web API
 
         Args:

--- a/slackclient/_slackrequest.py
+++ b/slackclient/_slackrequest.py
@@ -45,7 +45,7 @@ class SlackRequest(object):
 
     def append_user_agent(self, name, version):
         name = str.replace(name, "/", ":")
-        version = str.replace(name, "/", ":")
+        version = str.replace(version, "/", ":")
         if self.custom_user_agent:
             self.custom_user_agent.append([name, version])
         else:

--- a/slackclient/version.py
+++ b/slackclient/version.py
@@ -1,0 +1,2 @@
+# see: http://legacy.python.org/dev/peps/pep-0440/#public-version-identifiers
+__version__ = '1.0.4'

--- a/tests/test_slackrequest.py
+++ b/tests/test_slackrequest.py
@@ -2,18 +2,30 @@ from slackclient._slackrequest import SlackRequest
 import json
 import os
 
-def test_post_headers(mocker):
+def test_http_headers(mocker):
     requests = mocker.patch('slackclient._slackrequest.requests')
-    SlackRequest.do('xoxb-123', 'chat.postMessage', {'text': 'test', 'channel': '#general'})
+    request = SlackRequest()
+
+    request.append_user_agent("fooagent1","0.1")
+    request.append_user_agent("baragent/2","0.2")
+
+    request.do('xoxb-123', 'chat.postMessage', {'text': 'test', 'channel': '#general'})
 
     args, kwargs = requests.post.call_args
     assert None != kwargs['headers']['user-agent']
+
+    # Verify user-agent includes both default and custom agent info
     assert "slackclient" in kwargs['headers']['user-agent']
+    assert "fooagent1" in kwargs['headers']['user-agent']
+
+    # verify escaping of slashes in custom agent name
+    assert "baragent:2" in kwargs['headers']['user-agent']
 
 def test_post_file(mocker):
     requests = mocker.patch('slackclient._slackrequest.requests')
+    request = SlackRequest()
 
-    response = SlackRequest.do('xoxb-123',
+    response = request.do('xoxb-123',
         'files.upload',
         {'file': open(os.path.join('.', 'tests', 'data', 'slack_logo.png'), 'rb'),
             'filename': 'slack_logo.png'})
@@ -27,8 +39,9 @@ def test_post_file(mocker):
 
 def test_get_file(mocker):
     requests = mocker.patch('slackclient._slackrequest.requests')
+    request = SlackRequest()
 
-    SlackRequest.do('xoxb-123', 'files.info', {'file': 'myFavoriteFileID'})
+    request.do('xoxb-123', 'files.info', {'file': 'myFavoriteFileID'})
 
     assert requests.post.call_count == 1
     args, kwargs = requests.post.call_args
@@ -39,8 +52,9 @@ def test_get_file(mocker):
 
 def test_post_attachements(mocker):
     requests = mocker.patch('slackclient._slackrequest.requests')
+    request = SlackRequest()
 
-    SlackRequest.do('xoxb-123',
+    request.do('xoxb-123',
                     'chat.postMessage',
                     {'attachments': [{'title': 'hello'}]})
 

--- a/tests/test_slackrequest.py
+++ b/tests/test_slackrequest.py
@@ -1,4 +1,5 @@
 from slackclient._slackrequest import SlackRequest
+from slackclient.version import __version__
 import json
 import os
 
@@ -22,11 +23,11 @@ def test_custom_user_agent(mocker):
     args, kwargs = requests.post.call_args
 
     # Verify user-agent includes both default and custom agent info
-    assert "slackclient" in kwargs['headers']['user-agent']
-    assert "fooagent1" in kwargs['headers']['user-agent']
+    assert "slackclient/{}".format(__version__) in kwargs['headers']['user-agent']
+    assert "fooagent1/0.1" in kwargs['headers']['user-agent']
 
     # verify escaping of slashes in custom agent name
-    assert "baragent:2" in kwargs['headers']['user-agent']
+    assert "baragent:2/0.2" in kwargs['headers']['user-agent']
 
 def test_post_file(mocker):
     requests = mocker.patch('slackclient._slackrequest.requests')

--- a/tests/test_slackrequest.py
+++ b/tests/test_slackrequest.py
@@ -2,6 +2,14 @@ from slackclient._slackrequest import SlackRequest
 import json
 import os
 
+def test_post_headers(mocker):
+    requests = mocker.patch('slackclient._slackrequest.requests')
+    SlackRequest.do('xoxb-123', 'chat.postMessage', {'text': 'test', 'channel': '#general'})
+
+    args, kwargs = requests.post.call_args
+    assert None != kwargs['headers']['user-agent']
+    assert "slackclient" in kwargs['headers']['user-agent']
+
 def test_post_file(mocker):
     requests = mocker.patch('slackclient._slackrequest.requests')
 

--- a/tests/test_slackrequest.py
+++ b/tests/test_slackrequest.py
@@ -17,7 +17,6 @@ def test_custom_user_agent(mocker):
 
     request.append_user_agent("fooagent1","0.1")
     request.append_user_agent("baragent/2","0.2")
-    assert "fooagent1/0.1" in request.get_user_agent()
 
     request.do('xoxb-123', 'chat.postMessage', {'text': 'test', 'channel': '#general'})
     args, kwargs = requests.post.call_args


### PR DESCRIPTION
#### PR Summary
> Adds `user-agent` headers to Web API requests.

#### Test strategy
> Added tests.

✅ I've read and understood the [Contributing guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
✅ I've read and agree to the [Code of Conduct](https://github.com/slackapi/python-slackclient/blob/master/CODE_OF_CONDUCT.md).
✅ I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
✅ I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferably).
✅ I've written tests to cover the new code and functionality included in this PR.
✅ I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).
