### PR TITLE
Added timeout to api calls.

### DIFF
--- a/slackclient/_client.py
+++ b/slackclient/_client.py
@@ -44,7 +44,7 @@ class SlackClient(object):
         except:
             return False
 
-    def api_call(self, method, **kwargs):
+    def api_call(self, method, timeout=None, **kwargs):
         '''
         Call the Slack Web API as documented here: https://api.slack.com/web
 
@@ -74,7 +74,7 @@ class SlackClient(object):
 
             See here for more information on responses: https://api.slack.com/web
         '''
-        result = json.loads(self.server.api_call(method, **kwargs))
+        result = json.loads(self.server.api_call(method, timeout=timeout, **kwargs))
         if self.server:
             if method == 'im.open':
                 if "ok" in result and result["ok"]:

--- a/slackclient/_server.py
+++ b/slackclient/_server.py
@@ -61,8 +61,8 @@ class Server(object):
     def __repr__(self):
         return self.__str__()
 
-    def rtm_connect(self, reconnect=False):
-        reply = self.api_requester.do(self.token, "rtm.start")
+    def rtm_connect(self, reconnect=False, timeout=None):
+        reply = self.api_requester.do(self.token, "rtm.start", timeout=timeout)
         if reply.status_code != 200:
             raise SlackConnectionError
         else:
@@ -157,7 +157,7 @@ class Server(object):
         if self.channels.find(channel_id) is None:
             self.channels.append(Channel(self, name, channel_id, members))
 
-    def join_channel(self, name):
+    def join_channel(self, name, timeout=None):
         '''
         Join a channel by name.
 
@@ -165,16 +165,18 @@ class Server(object):
         '''
         return self.api_requester.do(
             self.token,
-            "channels.join?name={}".format(name)
+            "channels.join?name={}".format(name),
+            timeout=timeout
         ).text
 
-    def api_call(self, method, **kwargs):
+    def api_call(self, method, timeout=None, **kwargs):
         '''
         Call the Slack Web API as documented here: https://api.slack.com/web
 
         :Args:
             method (str): The API Method to call. See here for a list: https://api.slack.com/methods
         :Kwargs:
+            (optional) timeout: stop waiting for a response after a given number of seconds
             (optional) kwargs: any arguments passed here will be bundled and sent to the api
             requester as post_data
                 and will be passed along to the API.
@@ -198,7 +200,7 @@ class Server(object):
 
             See here for more information on responses: https://api.slack.com/web
         '''
-        return self.api_requester.do(self.token, method, kwargs).text
+        return self.api_requester.do(self.token, method, kwargs, timeout=timeout).text
 
 
 class SlackConnectionError(Exception):

--- a/slackclient/_slackrequest.py
+++ b/slackclient/_slackrequest.py
@@ -7,13 +7,14 @@ import six
 class SlackRequest(object):
 
     @staticmethod
-    def do(token, request="?", post_data=None, domain="slack.com"):
+    def do(token, request="?", post_data=None, domain="slack.com", timeout=None):
         '''
         Perform a POST request to the Slack Web API
 
         Args:
             token (str): your authentication token
             request (str): the method to call from the Slack API. For example: 'channels.list'
+            timeout (float): stop waiting for a response after a given number of seconds
             post_data (dict): key/value arguments to pass for the request. For example:
                 {'channel': 'CABC12345'}
             domain (str): if for some reason you want to send your request to something other
@@ -36,4 +37,4 @@ class SlackRequest(object):
         url = 'https://{0}/api/{1}'.format(domain, request)
         post_data['token'] = token
 
-        return requests.post(url, data=post_data, files=files)
+        return requests.post(url, data=post_data, files=files, timeout=timeout)


### PR DESCRIPTION
* [x] I've read and understood the [Contributing guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/slackapi/python-slackclient/blob/master/CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferably).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
From the requests [documentation](http://docs.python-requests.org/en/master/user/quickstart/#timeouts) regarding the timeout parameter:
> Nearly all production code should use this parameter in nearly all requests. Failure to do so can cause your program to hang indefinitely

Previously there was no timeout on the Api calls, and you could end up hanging indefinitely. This PR adds the option to add timeout, but defaults to keeping the existing behaviour.

#### Test strategy
There are no tests. Suggestions as to how to test are welcomed...
