### PR TITLE
Allow Channel.send_message to reply to a thread

### DIFF
--- a/docs-src/real_time_messaging.rst
+++ b/docs-src/real_time_messaging.rst
@@ -76,6 +76,22 @@ You can send a message to Slack by sending JSON over the websocket connection.
 You can send a message to a private group or direct message channel in the same
 way, but using a Group ID (``C024BE91L``) or DM channel ID (``D024BE91L``).
 
+You can send a message in reply to a thread using the ``thread`` argument, and
+optionally broadcast that message back to the channel by setting
+``reply_broadcast`` to ``True``.
+
+::
+
+  from slackclient import SlackClient
+
+  slack_token = os.environ["SLACK_API_TOKEN"]
+  sc = SlackClient(slack_token)
+
+  sc.rtm_send_message("welcome-test", "test", "1482960137.003543", True)
+
+See `Threading messages <https://api.slack.com/docs/message-threading#threads_party>`_
+for more details on using threads.
+
 The RTM API only supports posting messages with `basic formatting <https://api.slack.com/docs/message-formatting>`_.
 It does not support attachments or other message formatting modes.
 

--- a/slackclient/_channel.py
+++ b/slackclient/_channel.py
@@ -26,15 +26,27 @@ class Channel(object):
     def __repr__(self):
         return self.__str__()
 
-    def send_message(self, message):
+    def send_message(self, message, thread=None, reply_broadcast=False):
         '''
         Sends a message to a this Channel.
 
+        Include the parent message's thread_ts value in `thread`
+        to send to a thread.
+
         :Args:
             message (message) - the string you'd like to send to the channel
+            thread (str or None) - the parent message ID, if sending to a
+                thread
+            reply_broadcast (bool) - if messaging a thread, whether to
+                also send the message back to the channel
 
         :Returns:
             None
         '''
         message_json = {"type": "message", "channel": self.id, "text": message}
+        if thread is not None:
+            message_json["thread_ts"] = thread
+            if reply_broadcast:
+                message_json['reply_broadcast'] = True
+
         self.server.send_to_websocket(message_json)

--- a/slackclient/_client.py
+++ b/slackclient/_client.py
@@ -131,7 +131,7 @@ class SlackClient(object):
         else:
             raise SlackNotConnected
 
-    def rtm_send_message(self, channel, message):
+    def rtm_send_message(self, channel, message, thread=None, reply_broadcast=None):
         '''
         Sends a message to a given channel.
 
@@ -139,12 +139,20 @@ class SlackClient(object):
             channel (str) - the string identifier for a channel or channel name (e.g. 'C1234ABC',
             'bot-test' or '#bot-test')
             message (message) - the string you'd like to send to the channel
+            thread (str or None) - the parent message ID, if sending to a
+                thread
+            reply_broadcast (bool) - if messaging a thread, whether to
+                also send the message back to the channel
 
         :Returns:
             None
 
         '''
-        return self.server.channels.find(channel).send_message(message)
+        return self.server.channels.find(channel).send_message(
+            message,
+            thread,
+            reply_broadcast,
+        )
 
     def process_changes(self, data):
         '''

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -26,6 +26,33 @@ def test_channel_is_hashable(channel):
     assert channel_map[channel] == 'C12345678'
     assert (channel_map[channel] == 'foo') is False
 
-@pytest.mark.xfail
-def test_channel_send_message(channel):
+
+def test_channel_send_message(channel, mocker, monkeypatch):
+    mock_server = mocker.Mock()
+    monkeypatch.setattr(channel, 'server', mock_server)
     channel.send_message('hi')
+    mock_server.send_to_websocket.assert_called_with({
+        'text': 'hi',
+        'channel': channel.id,
+        'type': 'message',
+    })
+
+
+def test_channel_send_message_to_thread(channel, mocker, monkeypatch):
+    mock_server = mocker.Mock()
+    monkeypatch.setattr(channel, 'server', mock_server)
+    channel.send_message('hi', thread='123456.789')
+    mock_server.send_to_websocket.assert_called_with({
+        'text': 'hi',
+        'channel': channel.id,
+        'type': 'message',
+        'thread_ts': '123456.789',
+    })
+    channel.send_message('hi', thread='123456.789', reply_broadcast=True)
+    mock_server.send_to_websocket.assert_called_with({
+        'text': 'hi',
+        'channel': channel.id,
+        'type': 'message',
+        'thread_ts': '123456.789',
+        'reply_broadcast': True,
+    })


### PR DESCRIPTION
* [x] I've read and understood the [Contributing guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/slackapi/python-slackclient/blob/master/CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferably).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
This PR adds two keyword arguments to `slackclient._channel.Channel.send_message`: `thread` and `reply_broadcast`. These allow a message sent using this method to be marked as a reply to a thread, and optionally to be posted back to the channel.

This makes it easier to meet Slack's Best Practices for bots (https://api.slack.com/docs/message-threading#best_practices) which states that they should reply to threaded messages in the same thread.

It also fixes the test for send_message by monkeypatching the server attribute, and adds an extra test for the new functionality.

#### Related Issues
None

#### Test strategy
> e.g. Add tests around whatsit production.
