### PR TITLE
Allow extra arguments with ping.

### DIFF
--- a/slackclient/_server.py
+++ b/slackclient/_server.py
@@ -134,7 +134,7 @@ class Server(object):
 
         :Args:
             pingid (Optional[int]): The id of the ping. The reply_to
-                value of the response pongwill use this value. This
+                value of the response pong will use this value. This
                 argument takes priority of the id key in kwargs, if
                 present.
         :Kwargs:

--- a/slackclient/_server.py
+++ b/slackclient/_server.py
@@ -123,12 +123,34 @@ class Server(object):
         """
         try:
             data = json.dumps(data)
-            self.websocket.send(data)
+            return self.websocket.send(data)
         except:
             self.rtm_connect(reconnect=True)
+        return None
 
-    def ping(self):
-        return self.send_to_websocket({"type": "ping"})
+    def ping(self, pingid=None, **kwargs):
+        """ Send a ping message over the websocket. ping accepts any
+        key:value: pair and returns those values with the pong response.
+
+        :Args:
+            pingid (Optional[int]): The id of the ping. The reply_to
+                value of the response pongwill use this value. This
+                argument takes priority of the id key in kwargs, if
+                present.
+        :Kwargs:
+            (Optional) Any kwy:value pairs to be included in the ping.
+
+        :Example:
+            sc.server.ping(1234, timestamp=time.time())
+
+        :Returns:
+            (id, bytes_sent) tuple. If bytes_sent is None, the send
+                failed.
+        """
+        if pingid:
+            kwargs["id"] = pingid
+        kwargs["type"] = "ping"
+        return kwargs.get("id"), self.send_to_websocket(kwargs)
 
     def websocket_safe_read(self):
         """ Returns data if available, otherwise ''. Newlines indicate multiple

--- a/slackclient/_server.py
+++ b/slackclient/_server.py
@@ -129,8 +129,8 @@ class Server(object):
         return None
 
     def ping(self, pingid=None, **kwargs):
-        """ Send a ping message over the websocket. ping accepts any
-        key:value: pair and returns those values with the pong response.
+        """ Send a ping message over the websocket. ping accepts any 
+        key-value pair and returns those values with the pong response
 
         :Args:
             pingid (Optional[int]): The id of the ping. The reply_to


### PR DESCRIPTION
* [x] I've read and understood the [Contributing guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/slackapi/python-slackclient/blob/master/CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferably).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
Added functionality to the `Server.ping` function that allows the user to include an ID as well as any other key:value pairs that they want.

I wrote this because I wanted to associate `pong` messages with the corresponding `ping` to ensure I wasn't missing any and the only way to do that from user code was to bypass `ping`.

There are a few parts that I am unsure about:
1. The return value from `send_to_websocket`. I wanted to return something that would inform the user that the message didn't go through. More mature developers may have an opinion of whether that is useful or not.
1. I've never written docstrings for a function with **kwargs, so that may be wrong as well.
1. I considered generating a random ID if no ID was included but decided that was overstepping. If anyone thinks that is a good idea, I can add it.

#### Related Issues
N/A

#### Test strategy
I added tests to check that ping forwards the extra arguments correctly.
