### PR TITLE
Extent too short Title underline in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,7 +92,7 @@ page for a full list of formatting and authorship options.
 
 
 Replying to messages and creating threads
-********************
+*****************************************
 Threaded messages are just like regular messages, except thread replies are grouped together to provide greater context
 to the user. You can reply to a thread or start a new threaded conversation by simply passing the original message's ``ts``
 ID in the ``thread_ts`` attribute when posting a message. If you're replying to a threaded message, you'll pass the `thread_ts`


### PR DESCRIPTION
* [x] I've read and understood the [Contributing guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/slackapi/python-slackclient/blob/master/CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferably).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
Fix rst warning in README. This may be why the pypi homepage for this package is unstyled, so the PKG-INFO should be updated when this is merged.

#### Test strategy
Confirm warning:
```<div class="system-message">
<p class="system-message-title">System Message: WARNING/2 (<tt class="docutils">README.rst</tt>, line 95)</p>
<p>Title underline too short.</p>
<pre class="literal-block">
Replying to messages and creating threads
********************
</pre>
</div>
```
is no longer present when the README is rendered with rst2html.