### PR TITLE
Specify which exceptions are caught and which are not

### DIFF
--- a/slackclient/_client.py
+++ b/slackclient/_client.py
@@ -44,7 +44,7 @@ class SlackClient(object):
         try:
             self.server.rtm_connect()
             return True
-        except:
+        except Exception:
             return False
 
     def api_call(self, method, timeout=None, **kwargs):

--- a/slackclient/_server.py
+++ b/slackclient/_server.py
@@ -2,8 +2,10 @@ from slackclient._slackrequest import SlackRequest
 from slackclient._channel import Channel
 from slackclient._user import User
 from slackclient._util import SearchList, SearchDict
+import socket
 from ssl import SSLError
 
+import websocket
 from websocket import create_connection
 import json
 
@@ -91,7 +93,7 @@ class Server(object):
         try:
             self.websocket = create_connection(ws_url)
             self.websocket.sock.setblocking(0)
-        except:
+        except (websocket.WebSocketException, socket.error):
             raise SlackConnectionError
 
     def parse_channel_data(self, channel_data):
@@ -124,7 +126,7 @@ class Server(object):
         try:
             data = json.dumps(data)
             self.websocket.send(data)
-        except:
+        except websocket.WebSocketException:
             self.rtm_connect(reconnect=True)
 
     def ping(self):


### PR DESCRIPTION
Catching all exceptions with a blanket 'except:' is an
anti-pattern, and one that a client library like this
library should not be doing, because it to aggressively
catches things that it should not catch.

Read over:

https://docs.python.org/2/howto/doanddont.html#except

* [x] I've read and understood the [Contributing guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/slackapi/python-slackclient/blob/master/CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferably).
* [ ] I've written tests to cover the new code and functionality included in this PR.
* [ ] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary

#### Related Issues

#### Test strategy
