### PR TITLE
Connect to websocket before parsing team/channel/user data

### DIFF
--- a/slackclient/server.py
+++ b/slackclient/server.py
@@ -74,9 +74,9 @@ class Server(object):
             login_data = reply.json()
             if login_data["ok"]:
                 self.ws_url = login_data['url']
+                self.connect_slack_websocket(self.ws_url)
                 if not reconnect:
                     self.parse_slack_login_data(login_data)
-                self.connect_slack_websocket(self.ws_url)
             else:
                 raise SlackLoginError
 


### PR DESCRIPTION
###  Summary

Fixes #127 

By connecting to the websocket before parsing the contents of `rtm.start`, users should experience less timeouts in very large teams because the websocket URL is only valid for 30 seconds.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).