### PR TITLE
Add http reply into slack login and slack connection error

### DIFF
--- a/slackclient/server.py
+++ b/slackclient/server.py
@@ -70,7 +70,7 @@ class Server(object):
         reply = self.api_requester.do(self.token, "rtm.start", timeout=timeout)
 
         if reply.status_code != 200:
-            raise SlackConnectionError
+            raise SlackConnectionError(reply=reply)
         else:
             login_data = reply.json()
             if login_data["ok"]:
@@ -79,7 +79,7 @@ class Server(object):
                 if not reconnect:
                     self.parse_slack_login_data(login_data)
             else:
-                raise SlackLoginError
+                raise SlackLoginError(reply=reply)
 
     def parse_slack_login_data(self, login_data):
         self.login_data = login_data
@@ -107,7 +107,7 @@ class Server(object):
                                                http_proxy_auth=proxy_auth)
             self.websocket.sock.setblocking(0)
         except Exception as e:
-            raise SlackConnectionError(str(e))
+            raise SlackConnectionError(message=str(e))
 
     def parse_channel_data(self, channel_data):
         for channel in channel_data:
@@ -226,8 +226,12 @@ class SlackCongigurationError(Exception):
 
 
 class SlackConnectionError(Exception):
-    pass
+    def __init__(self, message='', reply=None):
+        super(SlackConnectionError, self).__init__(message)
+        self.reply = reply
 
 
 class SlackLoginError(Exception):
-    pass
+    def __init__(self, message='', reply=None):
+        super(SlackLoginError, self).__init__(message)
+        self.reply = reply


### PR DESCRIPTION

###  Summary

It is quite useful to have these exceptions contain the reply
that caused the failure (especially for example when checking
for a 429 status code and backing off further requests). Right
now it is impossible to determine what the underlying issue
was and react appropriatly to it.

### Requirements (place an `x` in each `[ ]`)

* [ x ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [ x ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).