### PR TITLE
Fixed rtm_send_message channel ID

### DIFF
--- a/slackclient/client.py
+++ b/slackclient/client.py
@@ -156,7 +156,7 @@ class SlackClient(object):
         # The `channel` argument can be a channel name or an ID. At first its assumed to be a
         # name and an attempt is made to find the ID in the workspace state cache.
         # If that lookup fails, the argument is used as the channel ID.
-        found_channel = self.server.channels.find(channel).id
+        found_channel = self.server.channels.find(channel)
         channel_id = found_channel.id if found_channel.id else channel
         return self.server.rtm_send_message(
             channel_id,


### PR DESCRIPTION
###  Summary

1.0.8 release broke `rtm_send_message` due to a misplaced shannel ID reference.
### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).