### PR TITLE
Fix link to rtm.connect docs

### DIFF
--- a/docs-src/real_time_messaging.rst
+++ b/docs-src/real_time_messaging.rst
@@ -70,7 +70,7 @@ To do this, simply pass `with_team_state=False` into the `rtm_connect` call, lik
       print "Connection Failed"
 
 
-See the `rtm.start docs <https://api.slack.com/methods/rtm.start>`_ and the `rtm.connect docs<https://api.slack.com/methods/rtm.connect>`_
+See the `rtm.start docs <https://api.slack.com/methods/rtm.start>`_ and the `rtm.connect docs <https://api.slack.com/methods/rtm.connect>`_
 for more details.
 
 

--- a/docs/real_time_messaging.html
+++ b/docs/real_time_messaging.html
@@ -192,7 +192,7 @@ the Web API separately.</p>
     <span class="k">print</span> <span class="s2">&quot;Connection Failed&quot;</span>
 </pre></div>
 </div>
-<p>See the <a class="reference external" href="https://api.slack.com/methods/rtm.start">rtm.start docs</a> and the <a href="#id3"><span class="problematic" id="id4">`rtm.connect docs&lt;https://api.slack.com/methods/rtm.connect&gt;`_</span></a>
+<p>See the <a class="reference external" href="https://api.slack.com/methods/rtm.start">rtm.start docs</a> and the <a class="reference external" href="https://api.slack.com/methods/rtm.connect">rtm.connect docs</a>
 for more details.</p>
 </div>
 <div class="section" id="rtm-events">


### PR DESCRIPTION
###  Summary

Fix link to rtm.connect docs in `docs-src/real_time_messaging.rst`

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).