### PR TITLE
Fix rtm_send_message bug

### DIFF
--- a/slackclient/client.py
+++ b/slackclient/client.py
@@ -157,7 +157,7 @@ class SlackClient(object):
         # name and an attempt is made to find the ID in the workspace state cache.
         # If that lookup fails, the argument is used as the channel ID.
         found_channel = self.server.channels.find(channel)
-        channel_id = found_channel.id if found_channel.id else channel
+        channel_id = found_channel.id if found_channel else channel
         return self.server.rtm_send_message(
             channel_id,
             message,


### PR DESCRIPTION
###  Summary

Describe the goal of this PR. Mention any related Issue numbers.

Currently in the rtm_send_message function in client.py, if the channel is not found
```
channel_id = found_channel.id if found_channel.id else channel
```
generates the following error.

```
Traceback (most recent call last):
  File "/venv/lib/python3.6/site-packages/slackclient/client.py", line 160, in rtm_send_message
    channel_id = found_channel.id if found_channel.id else channel
AttributeError: 'NoneType' object has no attribute 'id'
```
This patch fixes the error by removing the 'id' attribute from the if statement.

### Requirements (place an `x` in each `[ ]`)

* [x ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [ x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).