### PR TITLE
removes statement about future python 3 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,9 +29,6 @@ of Python to get your project up and running as quickly as possible.
 Requirements and Installation
 ******************************
 
-Slack Developer Kit for Python currently works with Python 2.7 (watch for Python 3 support in the future), and requires `PyPI` to install
-dependencies. Of course, since you probably installed this module with `PyPI`, this is not a problem.
-
 We recommend using `PyPI <https://pypi.python.org/pypi>`_ to install Slack Developer Kit for Python
 
 .. code-block:: bash


### PR DESCRIPTION
fixes #165

###  Summary

Python 3 is now supported!

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).