### PR TITLE
Removed unused exception class, fixes #227

### DIFF
--- a/slackclient/server.py
+++ b/slackclient/server.py
@@ -251,10 +251,6 @@ class Server(object):
         return self.api_requester.do(self.token, method, kwargs, timeout=timeout).text
 
 
-class SlackCongigurationError(Exception):
-    pass
-
-
 class SlackConnectionError(Exception):
     pass
 


### PR DESCRIPTION
###  Summary
Fixes #227 
Removing an unused exception class, which is also misspelled.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).