### PR TITLE
adds new SlackClientError and ResponseParseError types

### DIFF
--- a/slackclient/client.py
+++ b/slackclient/client.py
@@ -5,6 +5,7 @@ import json
 import traceback
 
 from .server import Server
+from .exceptions import ParseResponseError
 
 
 class SlackClient(object):
@@ -84,7 +85,11 @@ class SlackClient(object):
 
             See here for more information on responses: https://api.slack.com/web
         '''
-        result = json.loads(self.server.api_call(method, timeout=timeout, **kwargs))
+        response_body = self.server.api_call(method, timeout=timeout, **kwargs)
+        try:
+            result = json.loads(response_body)
+        except ValueError as json_decode_error:
+            raise ParseResponseError(response_body, json_decode_error)
         if self.server:
             if method == 'im.open':
                 if "ok" in result and result["ok"]:

--- a/slackclient/exceptions.py
+++ b/slackclient/exceptions.py
@@ -1,0 +1,23 @@
+class SlackClientError(Exception):
+    """
+    Base exception for all errors raised by the SlackClient library
+    """
+    def __init__(self, msg=None):
+        if msg is None:
+            # default error message
+            msg = "An error occurred in the SlackClient library"
+        super(SlackClientError, self).__init__(msg)
+
+
+class ParseResponseError(SlackClientError, ValueError):
+    """
+    Error raised when responses to Web API methods cannot be parsed as valid JSON
+    """
+    def __init__(self, response_body, original_exception):
+        super(ParseResponseError, self).__init__(
+            "Slack API response body could not be parsed: {0}. Original exception: {1}".format(
+                response_body, original_exception
+            )
+        )
+        self.response_body = response_body
+        self.original_exception = original_exception

--- a/slackclient/server.py
+++ b/slackclient/server.py
@@ -3,6 +3,7 @@ from requests.packages.urllib3.util.url import parse_url
 from .channel import Channel
 from .user import User
 from .util import SearchList, SearchDict
+from .exceptions import SlackClientError
 from ssl import SSLError
 
 from websocket import create_connection
@@ -256,14 +257,18 @@ class Server(object):
         '''
         return self.api_requester.do(self.token, method, kwargs, timeout=timeout).text
 
+# TODO: Move the error types defined below into the .exceptions namespace. This would be a semver
+# major change because any clients already referencing these types in order to catch them
+# specifically would need to deal with the symbol names changing.
 
-class SlackConnectionError(Exception):
+
+class SlackConnectionError(SlackClientError):
     def __init__(self, message='', reply=None):
         super(SlackConnectionError, self).__init__(message)
         self.reply = reply
 
 
-class SlackLoginError(Exception):
+class SlackLoginError(SlackClientError):
     def __init__(self, message='', reply=None):
         super(SlackLoginError, self).__init__(message)
         self.reply = reply


### PR DESCRIPTION
###  Summary

Adding new error types to describe errors.

`SlackClientError` is the base class for all errors thrown from this package. It provides a generic default message if none is provided.

`ResponseParseError` is an error for Web API responses which cannot be parsed as JSON. Its message includes the response body and the message for the exception it wraps.

I attempted to follow best practices according to [this guide](https://julien.danjou.info/blog/2016/python-exceptions-guide).

I could spend some time writing tests, but I wanted to get this PR submitted for code review ASAP.

FYI: The new error types are in a new namespace called `.exceptions`. The existing custom error types `SlackConnectionError` and `SlackLoginError` should be moved under this namespace, but cannot be moved without bumping the major version number. This is noted in a comment. Upon acceptance of this PR, we should make an issue to track this issue and mark it as `semver:major`.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).