### PR TITLE
add login data getter

### DIFF
--- a/slackclient/client.py
+++ b/slackclient/client.py
@@ -205,5 +205,6 @@ class SlackClient(object):
             return self.server.login_data['self']
         return None
 
+
 class SlackNotConnected(Exception):
     pass

--- a/slackclient/client.py
+++ b/slackclient/client.py
@@ -193,6 +193,17 @@ class SlackClient(object):
                 self.server.parse_user_data([user])
             pass
 
+    def get_login_data(self):
+        """Fetch logged in data.
+        response:
+            id: id of logged in user.
+            name: name of the logged in user.
+            etc: all data related to logged in user
+        return: dict of data | None
+        """
+        if self.server.login_data and 'self' in self.server.login_data:
+            return self.server.login_data['self']
+        return None
 
 class SlackNotConnected(Exception):
     pass


### PR DESCRIPTION
###  Summary

I just used this library for bot communication. Apparently I need to now what's the logged in bot id and act as filter to avoid self replying when checking the message from `rtm_read()`. So I need to get the `login_data` which is set in `server.py` in `parse_slack_login_data()`. I cannot access that from slackclient. So I added `get_login_data()` for this. 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).