### PR TITLE
Moved `token` into Authorization header

### DIFF
--- a/slackclient/slackrequest.py
+++ b/slackclient/slackrequest.py
@@ -1,7 +1,7 @@
 import json
 
 import requests
-import six
+import six  # noqa: F401
 
 import sys
 import platform

--- a/slackclient/slackrequest.py
+++ b/slackclient/slackrequest.py
@@ -63,7 +63,7 @@ class SlackRequest(object):
         url = 'https://{0}/api/{1}'.format(domain, request)
 
         # Override token header if token is passed in form params
-        if "token" in post_data:
+        if post_data is not None and "token" in post_data:
             token = post_data['token']
 
         headers = {

--- a/slackclient/slackrequest.py
+++ b/slackclient/slackrequest.py
@@ -60,28 +60,33 @@ class SlackRequest(object):
                 than slack.com
         """
 
+        url = 'https://{0}/api/{1}'.format(domain, request)
+
+        # Override token header if token is passed in form params
+        if "token" in post_data:
+            token = post_data['token']
+
+        headers = {
+            'user-agent': self.get_user_agent(),
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer {}'.format(token)
+        }
+
         # Pull file out so it isn't JSON encoded like normal fields.
         # Only do this for requests that are UPLOADING files; downloading files
         # use the 'file' argument to point to a File ID.
         post_data = post_data or {}
         upload_requests = ['files.upload']
+
         files = None
         if request in upload_requests:
             files = {'file': post_data.pop('file')} if 'file' in post_data else None
 
-        for k, v in six.iteritems(post_data):
-            if not isinstance(v, six.string_types):
-                post_data[k] = json.dumps(v)
-
-        url = 'https://{0}/api/{1}'.format(domain, request)
-        headers = {
-            'user-agent': self.get_user_agent(),
-            'Authorization': 'Bearer {}'.format(token)
-        }
-
-        return requests.post(url,
-                             headers=headers,
-                             data=post_data,
-                             files=files,
-                             timeout=timeout,
-                             proxies=self.proxies)
+        return requests.post(
+            url,
+            headers=headers,
+            data=json.dumps(post_data),
+            files=files,
+            timeout=timeout,
+            proxies=self.proxies
+        )

--- a/slackclient/slackrequest.py
+++ b/slackclient/slackrequest.py
@@ -74,8 +74,10 @@ class SlackRequest(object):
                 post_data[k] = json.dumps(v)
 
         url = 'https://{0}/api/{1}'.format(domain, request)
-        post_data['token'] = token
-        headers = {'user-agent': self.get_user_agent()}
+        headers = {
+            'user-agent': self.get_user_agent(),
+            'Authorization': 'Bearer {}'.format(token)
+        }
 
         return requests.post(url,
                              headers=headers,

--- a/tests/test_slackrequest.py
+++ b/tests/test_slackrequest.py
@@ -32,6 +32,16 @@ def test_custom_user_agent(mocker):
     assert "baragent:2/0.2" in kwargs['headers']['user-agent']
 
 
+def test_auth_header(mocker):
+    requests = mocker.patch('slackclient.slackrequest.requests')
+    request = SlackRequest()
+
+    request.do('xoxb-123', 'chat.postMessage', {'text': 'test', 'channel': '#general'})
+    args, kwargs = requests.post.call_args
+
+    assert "Bearer xoxb-123" in kwargs['headers']['Authorization']
+
+
 def test_post_file(mocker):
     requests = mocker.patch('slackclient.slackrequest.requests')
     request = SlackRequest()
@@ -44,8 +54,7 @@ def test_post_file(mocker):
 
     assert requests.post.call_count == 1
     assert 'https://slack.com/api/files.upload' == args[0]
-    assert {'filename': 'slack_logo.png',
-            'token': 'xoxb-123'} == kwargs['data']
+    assert {'filename': 'slack_logo.png'} == kwargs['data']
     assert kwargs['files'] is not None
 
 
@@ -58,8 +67,7 @@ def test_get_file(mocker):
 
     assert requests.post.call_count == 1
     assert 'https://slack.com/api/files.info' == args[0]
-    assert {'file': "myFavoriteFileID",
-            'token': 'xoxb-123'} == kwargs['data']
+    assert {'file': "myFavoriteFileID"} == kwargs['data']
     assert kwargs['files'] is None
 
 
@@ -74,6 +82,5 @@ def test_post_attachements(mocker):
 
     assert requests.post.call_count == 1
     assert 'https://slack.com/api/chat.postMessage' == args[0]
-    assert {'attachments': json.dumps([{'title': 'hello'}]),
-            'token': 'xoxb-123'} == kwargs['data']
+    assert {'attachments': json.dumps([{'title': 'hello'}])} == kwargs['data']
     assert kwargs['files'] is None

--- a/tests/test_slackrequest.py
+++ b/tests/test_slackrequest.py
@@ -54,7 +54,7 @@ def test_post_file(mocker):
 
     assert requests.post.call_count == 1
     assert 'https://slack.com/api/files.upload' == args[0]
-    assert {'filename': 'slack_logo.png'} == kwargs['data']
+    assert {'filename': 'slack_logo.png'} == json.loads(kwargs['data'])
     assert kwargs['files'] is not None
 
 
@@ -67,7 +67,7 @@ def test_get_file(mocker):
 
     assert requests.post.call_count == 1
     assert 'https://slack.com/api/files.info' == args[0]
-    assert {'file': "myFavoriteFileID"} == kwargs['data']
+    assert {'file': "myFavoriteFileID"} == json.loads(kwargs['data'])
     assert kwargs['files'] is None
 
 
@@ -82,5 +82,5 @@ def test_post_attachements(mocker):
 
     assert requests.post.call_count == 1
     assert 'https://slack.com/api/chat.postMessage' == args[0]
-    assert {'attachments': json.dumps([{'title': 'hello'}])} == kwargs['data']
+    assert {'attachments': [{'title': 'hello'}]} == json.loads(kwargs['data'])
     assert kwargs['files'] is None


### PR DESCRIPTION
###  Summary

To further the support for JSON POST on Web API endpoints, I've moved the auth token into a request header in lieu of passing it as a form param. the `api_call` signature remains the same.

See #253

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).