### PR TITLE
honor ratelimit responses

### DIFF
--- a/slackclient/server.py
+++ b/slackclient/server.py
@@ -11,6 +11,7 @@ import time
 from websocket import create_connection
 import json
 
+
 class Server(object):
     """
     The Server object owns the websocket connection and all attached channel information.
@@ -153,7 +154,6 @@ class Server(object):
             data (dict) the key/values to send the websocket.
 
         """
-        
         try:
             data = json.dumps(data)
             self.websocket.send(data)


### PR DESCRIPTION

###  Summary

Make the client code itself honor the ratelimited response, this is time.sleep for "retry-after" seconds and also retry errno 11 immediately from SSL (I ran into that during the rate-limiting episode).  

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
