### PR TITLE
Minor readability fixes

### DIFF
--- a/slackclient/slackrequest.py
+++ b/slackclient/slackrequest.py
@@ -26,7 +26,8 @@ class SlackRequest(object):
     def get_user_agent(self):
         # Check for custom user-agent and append if found
         if self.custom_user_agent:
-            custom_ua_list = ["/".join(client_info) for client_info in self.custom_user_agent]
+            custom_ua_list = ["/".join(client_info)
+                              for client_info in self.custom_user_agent]
             custom_ua_string = " ".join(custom_ua_list)
             self.default_user_agent['custom'] = custom_ua_string
 
@@ -40,7 +41,8 @@ class SlackRequest(object):
 
     def append_user_agent(self, name, version):
         if self.custom_user_agent:
-            self.custom_user_agent.append([name.replace("/", ":"), version.replace("/", ":")])
+            self.custom_user_agent.append(
+                [name.replace("/", ":"), version.replace("/", ":")])
         else:
             self.custom_user_agent = [[name, version]]
 
@@ -81,10 +83,12 @@ class SlackRequest(object):
         # Move file content into requests' `files` param
         files = None
         if request in upload_requests:
-            files = {'file': post_data.pop('file')} if 'file' in post_data else None
+            files = {'file': post_data.pop(
+                'file')} if 'file' in post_data else None
 
         # Check for plural fields and convert them to comma-separated strings if needed
-        for field in {'channels', 'users', 'types'} & set(post_data.keys()):
+        fields = {'channels', 'users', 'types'} & set(post_data.keys())
+        for field in fields:
             if isinstance(post_data[field], list):
                 post_data[field] = ",".join(post_data[field])
 

--- a/tests/test_slackrequest.py
+++ b/tests/test_slackrequest.py
@@ -8,7 +8,8 @@ def test_http_headers(mocker):
     requests = mocker.patch('slackclient.slackrequest.requests')
     request = SlackRequest()
 
-    request.do('xoxb-123', 'chat.postMessage', {'text': 'test', 'channel': '#general'})
+    request.do('xoxb-123', 'chat.postMessage',
+               {'text': 'test', 'channel': '#general'})
     args, kwargs = requests.post.call_args
 
     assert kwargs['headers']['user-agent'] is not None
@@ -21,11 +22,13 @@ def test_custom_user_agent(mocker):
     request.append_user_agent("fooagent1", "0.1")
     request.append_user_agent("baragent/2", "0.2")
 
-    request.do('xoxb-123', 'chat.postMessage', {'text': 'test', 'channel': '#general'})
+    request.do('xoxb-123', 'chat.postMessage',
+               {'text': 'test', 'channel': '#general'})
     args, kwargs = requests.post.call_args
 
     # Verify user-agent includes both default and custom agent info
-    assert "slackclient/{}".format(__version__) in kwargs['headers']['user-agent']
+    assert "slackclient/{}".format(
+        __version__) in kwargs['headers']['user-agent']
     assert "fooagent1/0.1" in kwargs['headers']['user-agent']
 
     # verify escaping of slashes in custom agent name
@@ -36,7 +39,8 @@ def test_auth_header(mocker):
     requests = mocker.patch('slackclient.slackrequest.requests')
     request = SlackRequest()
 
-    request.do('xoxb-123', 'chat.postMessage', {'text': 'test', 'channel': '#general'})
+    request.do('xoxb-123', 'chat.postMessage',
+               {'text': 'test', 'channel': '#general'})
     args, kwargs = requests.post.call_args
 
     assert "Bearer xoxb-123" in kwargs['headers']['Authorization']
@@ -51,7 +55,7 @@ def test_token_override(mocker):
                    'token': "newtoken",
                    'text': 'test',
                    'channel': '#general'
-                })
+               })
     args, kwargs = requests.post.call_args
 
     assert "Bearer newtoken" in kwargs['headers']['Authorization']
@@ -61,15 +65,25 @@ def test_plural_field(mocker):
     requests = mocker.patch('slackclient.slackrequest.requests')
     request = SlackRequest()
 
-    request.do('xoxb-123','conversations.open', {'users': ['U123', 'U234', 'U345']})
+    request.do('xoxb-123', 'conversations.open',
+               {'users': ['U123', 'U234', 'U345']})
     args, kwargs = requests.post.call_args
 
     assert kwargs['data'] == {'users': 'U123,U234,U345'}
 
-    request.do('xoxb-123','conversations.open', {'users': "U123,U234,U345"})
+    request.do('xoxb-123', 'conversations.open', {'users': "U123,U234,U345"})
     args2, kwargs2 = requests.post.call_args
 
     assert kwargs2['data'] == {'users': 'U123,U234,U345'}
+
+    test_plural_fields_data = {'users': ['U123', 'U234', 'U345'],
+                               'channel': 'C123,C234,C345'}
+
+    request.do('xoxb-123', 'conversations.open', test_plural_fields_data)
+    args2, kwargs2 = requests.post.call_args
+
+    assert kwargs2['data'] == {'users': 'U123,U234,U345',
+                               'channel': 'C123,C234,C345'}
 
 
 def test_post_file(mocker):

--- a/tests/test_slackrequest.py
+++ b/tests/test_slackrequest.py
@@ -27,8 +27,7 @@ def test_custom_user_agent(mocker):
     args, kwargs = requests.post.call_args
 
     # Verify user-agent includes both default and custom agent info
-    assert "slackclient/{}".format(
-        __version__) in kwargs['headers']['user-agent']
+    assert "slackclient/{}".format(__version__) in kwargs['headers']['user-agent']
     assert "fooagent1/0.1" in kwargs['headers']['user-agent']
 
     # verify escaping of slashes in custom agent name


### PR DESCRIPTION
###  Summary
- Field set intersection is much more readable
- Minor test to catch mixed csv/lists plural fields
- PEP8 autoformating.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).