### PR TITLE
Fix copy-and-paste error in docs

### DIFF
--- a/docs/basic_usage.html
+++ b/docs/basic_usage.html
@@ -411,7 +411,7 @@ joined one by accident. This is how you leave a channel.</p>
     <span class="p">)</span>
 </pre></div>
 </div>
-<p>See <a class="reference external" href="https://api.slack.com/methods/files.upload">users.list</a> for more info.</p>
+<p>See <a class="reference external" href="https://api.slack.com/methods/files.upload">files.upload</a> for more info.</p>
 </div>
 <hr class="docutils" />
 <div class="section" id="web-api-rate-limits">


### PR DESCRIPTION
###  Summary

Change the displayed text of a link to the linked method's name instead of the one from the previous section.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).