### PR TITLE
Use logging instead of traceback

### DIFF
--- a/slackclient/client.py
+++ b/slackclient/client.py
@@ -2,10 +2,12 @@
 # mostly a proxy object to abstract how some of this works
 
 import json
-import traceback
+import logging
 
 from .server import Server
 from .exceptions import ParseResponseError
+
+LOG = logging.getLogger(__name__)
 
 
 class SlackClient(object):
@@ -52,7 +54,7 @@ class SlackClient(object):
             self.server.rtm_connect(use_rtm_start=with_team_state, **kwargs)
             return self.server.connected
         except Exception:
-            traceback.print_exc()
+            LOG.warn("Failed RTM connect", exc_info=True)
             return False
 
     def api_call(self, method, timeout=None, **kwargs):


### PR DESCRIPTION
Instead of just outputting to stderr the rtm connect
failure it is more appropriate to use the python logging
system and output a appropriate message (and pass in
exc_info=True so that the traceback gets logged as well).

###  Summary

Describe the goal of this PR. Mention any related Issue numbers.

### Requirements (place an `x` in each `[ ]`)

* [ x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [ x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).