### PR TITLE
Add websocket enable_multithread pass-through

### DIFF
--- a/slackclient/client.py
+++ b/slackclient/client.py
@@ -26,11 +26,15 @@ class SlackClient(object):
             proxies (dict): Proxies to use when create websocket or api calls,
             declare http and websocket proxies using {'http': 'http://127.0.0.1'},
             and https proxy using {'https': 'https://127.0.0.1:443'}
+            enable_multithread: Enable the underlying websocket connection to
+            be thread safe (ie, locks will occur on read and write to avoid
+            contention).
     '''
-    def __init__(self, token, proxies=None):
+    def __init__(self, token, proxies=None, enable_multithread=False):
 
         self.token = token
-        self.server = Server(self.token, False, proxies)
+        self.server = Server(self.token, False, proxies,
+                             enable_multithread=enable_multithread)
 
     def append_user_agent(self, name, version):
         self.server.append_user_agent(name, version)

--- a/slackclient/server.py
+++ b/slackclient/server.py
@@ -21,7 +21,8 @@ class Server(object):
 
 
     """
-    def __init__(self, token, connect=True, proxies=None):
+    def __init__(self, token, connect=True, proxies=None,
+                 enable_multithread=False):
         # Slack client configs
         self.token = token
         self.proxies = proxies
@@ -42,6 +43,9 @@ class Server(object):
         self.last_connected_at = 0
         self.reconnect_count = 0
         self.rtm_connect_retries = 0
+
+        # This makes the whole websocket layer thread safe...
+        self.enable_multithread = enable_multithread
 
         # Connect to RTM on load
         if connect:
@@ -173,10 +177,10 @@ class Server(object):
             proxy_auth, proxy_port, proxy_host = None, None, None
 
         try:
-            self.websocket = create_connection(ws_url,
-                                               http_proxy_host=proxy_host,
-                                               http_proxy_port=proxy_port,
-                                               http_proxy_auth=proxy_auth)
+            self.websocket = create_connection(
+                ws_url, http_proxy_host=proxy_host,
+                http_proxy_port=proxy_port, http_proxy_auth=proxy_auth,
+                enable_multithread=self.enable_multithread)
             self.connected = True
             self.last_connected_at = time.time()
             logging.debug("RTM connected")


### PR DESCRIPTION
It seems this is needed to ensure that the
underlying websocket connection is actually thread
safe; and for bots and users that are doing things
in threads we need to make sure it's enabled.

###  Summary

Describe the goal of this PR. Mention any related Issue numbers.

### Requirements (place an `x` in each `[ ]`)

* [x ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).