### PR TITLE
 Move server exceptions

### DIFF
--- a/slackclient/exceptions.py
+++ b/slackclient/exceptions.py
@@ -1,3 +1,9 @@
+# Warning can be removed once we bump semver
+import warnings
+warnings.warn(
+'Exceptions: SlackConnectionError and SlackLoginError have been moved '
+'to exceptions imports from server are no longer supported and will be removed')
+
 class SlackClientError(Exception):
     """
     Base exception for all errors raised by the SlackClient library
@@ -21,3 +27,15 @@ class ParseResponseError(SlackClientError, ValueError):
         )
         self.response_body = response_body
         self.original_exception = original_exception
+
+
+class SlackConnectionError(SlackClientError):
+    def __init__(self, message='', reply=None):
+        super(SlackConnectionError, self).__init__(message)
+        self.reply = reply
+
+
+class SlackLoginError(SlackClientError):
+    def __init__(self, message='', reply=None):
+        super(SlackLoginError, self).__init__(message)
+        self.reply = reply

--- a/slackclient/exceptions.py
+++ b/slackclient/exceptions.py
@@ -1,8 +1,10 @@
 # Warning can be removed once we bump semver
 import warnings
 warnings.warn(
-'Exceptions: SlackConnectionError and SlackLoginError have been moved '
-'to exceptions imports from server are no longer supported and will be removed')
+    'Exceptions: SlackConnectionError and SlackLoginError have been moved '
+    'to exceptions imports from server are no longer supported and will be removed'
+)
+
 
 class SlackClientError(Exception):
     """

--- a/slackclient/server.py
+++ b/slackclient/server.py
@@ -1,7 +1,7 @@
 from .channel import Channel
-from .exceptions import SlackClientError
+from .exceptions import SlackClientError  # pylint: disable=unused-import
 # Imported manually as these are here to support backwards compatability
-from .exceptions import SlackConnectionError, SlackLoginError  # NOQA
+from .exceptions import SlackConnectionError, SlackLoginError  # pylint: disable=unused-import
 from .slackrequest import SlackRequest
 from .user import User
 from .util import SearchList, SearchDict

--- a/slackclient/server.py
+++ b/slackclient/server.py
@@ -1,5 +1,7 @@
 from .channel import Channel
 from .exceptions import SlackClientError
+# Imported manually as these are here to support backwards compatability
+from .exceptions import SlackConnectionError, SlackLoginError
 from .slackrequest import SlackRequest
 from .user import User
 from .util import SearchList, SearchDict

--- a/slackclient/server.py
+++ b/slackclient/server.py
@@ -340,19 +340,3 @@ class Server(object):
         response_json = json.loads(response.text)
         response_json["headers"] = dict(response.headers)
         return json.dumps(response_json)
-
-# TODO: Move the error types defined below into the .exceptions namespace. This would be a semver
-# major change because any clients already referencing these types in order to catch them
-# specifically would need to deal with the symbol names changing.
-
-
-class SlackConnectionError(SlackClientError):
-    def __init__(self, message='', reply=None):
-        super(SlackConnectionError, self).__init__(message)
-        self.reply = reply
-
-
-class SlackLoginError(SlackClientError):
-    def __init__(self, message='', reply=None):
-        super(SlackLoginError, self).__init__(message)
-        self.reply = reply

--- a/slackclient/server.py
+++ b/slackclient/server.py
@@ -1,7 +1,7 @@
 from .channel import Channel
 from .exceptions import SlackClientError
 # Imported manually as these are here to support backwards compatability
-from .exceptions import SlackConnectionError, SlackLoginError
+from .exceptions import SlackConnectionError, SlackLoginError  # NOQA
 from .slackrequest import SlackRequest
 from .user import User
 from .util import SearchList, SearchDict


### PR DESCRIPTION
###  Summary

Fixes the todo in `server.py` 
https://github.com/slackapi/python-slackclient/pull/318/files#diff-887c1bd9917042e0848d17632e66ab8cL342

Moves the exceptions to `exception.py`.
Reimports the exceptions back into `server.py` to keep backward compatibility

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).