### PR TITLE
Support additional ping flat arguments

### DIFF
--- a/slackclient/server.py
+++ b/slackclient/server.py
@@ -249,8 +249,13 @@ class Server(object):
 
         self.send_to_websocket(message_json)
 
-    def ping(self):
-        return self.send_to_websocket({"type": "ping"})
+    def ping(self, extra_flat_args=None):
+        out_data = {
+            'type': 'ping',
+        }
+        if extra_flat_args is not None:
+            out_data.update(extra_flat_args)
+        return self.send_to_websocket(out_data)
 
     def websocket_safe_read(self):
         """


### PR DESCRIPTION
The ping command can take extra arguments that can
be useful for things like latency checking; so allow these
types of arguments to be passed through.

###  Summary

Describe the goal of this PR. Mention any related Issue numbers.

### Requirements (place an `x` in each `[ ]`)

* [ x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [ x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).