### PR TITLE
Pass client params from Client to Server (#327)

### DIFF
--- a/slackclient/client.py
+++ b/slackclient/client.py
@@ -25,14 +25,17 @@ class SlackClient(object):
             token (str): Your Slack Authentication token. You can find or generate a test token
             `here <https://api.slack.com/docs/oauth-test-tokens>`_
             Note: Be `careful with your token <https://api.slack.com/docs/oauth-safety>`_
+            protocol (str): 'http' or 'https', default https
+            domain (str): default 'slack.com' (requires change if steno test framework used)
+            port (int|str): default port 443
             proxies (dict): Proxies to use when create websocket or api calls,
             declare http and websocket proxies using {'http': 'http://127.0.0.1'},
             and https proxy using {'https': 'https://127.0.0.1:443'}
     '''
-    def __init__(self, token, proxies=None):
+    def __init__(self, token, protocol='https', api_domain='slack.com', port=443, proxies=None):
 
         self.token = token
-        self.server = Server(self.token, False, proxies)
+        self.server = Server(self.token, False, protocol, api_domain, port, proxies)
 
     def append_user_agent(self, name, version):
         self.server.append_user_agent(name, version)

--- a/slackclient/server.py
+++ b/slackclient/server.py
@@ -21,11 +21,13 @@ class Server(object):
 
 
     """
-    def __init__(self, token, connect=True, proxies=None):
+    def __init__(self, token, connect=True, protocol="https", api_domain="slack.com",
+                 port=443, proxies=None):
         # Slack client configs
         self.token = token
         self.proxies = proxies
-        self.api_requester = SlackRequest(proxies=proxies)
+        self.api_requester = SlackRequest(
+            protocol=protocol, api_domain=api_domain, port=port, proxies=proxies)
 
         # Workspace metadata
         self.username = None

--- a/slackclient/slackrequest.py
+++ b/slackclient/slackrequest.py
@@ -7,7 +7,7 @@ from .version import __version__
 
 
 class SlackRequest(object):
-    def __init__(self, proxies=None):
+    def __init__(self, protocol="https", api_domain="slack.com", port=443, proxies=None):
 
         # __name__ returns 'slackclient.slackrequest', we only want 'slackclient'
         client_name = __name__.split('.')[0]
@@ -21,6 +21,9 @@ class SlackRequest(object):
         }
 
         self.custom_user_agent = None
+        self.protocol = protocol
+        self.api_domain = api_domain
+        self.port = port
         self.proxies = proxies
 
     def get_user_agent(self):
@@ -44,7 +47,7 @@ class SlackRequest(object):
         else:
             self.custom_user_agent = [[name, version]]
 
-    def do(self, token, request="?", post_data=None, domain="slack.com", timeout=None):
+    def do(self, token, request="?", post_data=None, timeout=None):
         """
         Perform a POST request to the Slack Web API
 
@@ -57,8 +60,10 @@ class SlackRequest(object):
             domain (str): if for some reason you want to send your request to something other
                 than slack.com
         """
-
-        url = 'https://{0}/api/{1}'.format(domain, request)
+        url = '{0}://{1}/api/{2}'.format(
+            self.protocol, self.api_domain, request) if (
+                self.api_domain == 'slack.com') else '{0}://{1}:{2}/api/{3}'.format(
+                        self.protocol, self.api_domain, self.port, request)
 
         # Override token header if `token` is passed in post_data
         if post_data is not None and "token" in post_data:


### PR DESCRIPTION
###  Summary

https://github.com/slackapi/python-slackclient/issues/327

Currently all tests are passing, however: 
- To get them to pass, default class vars are mentioned in several places. I'd like to set defaults only in SlackClient class, and pass these along, which would require changing some tests to pass these values, and then can add other tests like a localhost (for steno).

Would this be ok?

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).