### PR TITLE
Add additional object types to Web API JSON serializer

### DIFF
--- a/slackclient/slackrequest.py
+++ b/slackclient/slackrequest.py
@@ -1,8 +1,9 @@
 import json
 import platform
+import sys
+
 import requests
 import six
-import sys
 
 from .version import __version__
 
@@ -78,8 +79,16 @@ class SlackRequest(object):
         # Convert any params which are list-like to JSON strings
         # Example: `attachments` is a dict, and needs to be passed as JSON
         for k, v in six.iteritems(post_data):
-            if isinstance(v, (list, dict)):
+            if isinstance(v, (six.string_types, six.text_type)):
+                continue
+            elif isinstance(v, dict):
                 post_data[k] = json.dumps(v)
+            else:
+                # If the param is iterable, convert it to a JSON-serializable type
+                try:
+                    post_data[k] = json.dumps(tuple(v))
+                except TypeError:
+                    pass
 
         return self.post_http_request(token, request, post_data, files, timeout, domain)
 

--- a/tests/test_slackrequest.py
+++ b/tests/test_slackrequest.py
@@ -1,6 +1,7 @@
+import os
+
 from slackclient.slackrequest import SlackRequest
 from slackclient.version import __version__
-import os
 
 
 def test_http_headers(mocker):
@@ -104,11 +105,80 @@ def test_post_attachements(mocker):
     requests = mocker.patch('slackclient.slackrequest.requests')
     request = SlackRequest()
 
-    request.do('xoxb-123',
-               'chat.postMessage',
-               {'attachments': [{'title': 'hello'}]})
+    request.do(
+        'xoxb-123',
+        'chat.postMessage',
+        {
+            'list-param': [
+                {'title': 'List parameter'}
+            ]
+        }
+    )
     args, kwargs = requests.post.call_args
-
     assert requests.post.call_count == 1
     assert 'https://slack.com/api/chat.postMessage' == args[0]
-    assert isinstance(kwargs["data"]["attachments"], str)
+    assert isinstance(kwargs["data"]["list-param"], str)
+
+    request.do(
+        'xoxb-123',
+        'chat.postMessage',
+        {
+            'tuple-param': (
+                {'title': 'Tuple parameter'},
+            )
+        }
+    )
+    args, kwargs = requests.post.call_args
+    assert requests.post.call_count == 2
+    assert 'https://slack.com/api/chat.postMessage' == args[0]
+    assert isinstance(kwargs["data"]["tuple-param"], str)
+
+    request.do(
+        'xoxb-123',
+        'chat.postMessage',
+        {
+            'set-param': {1, 2, 3}
+        }
+    )
+    args, kwargs = requests.post.call_args
+    assert requests.post.call_count == 3
+    assert 'https://slack.com/api/chat.postMessage' == args[0]
+    assert isinstance(kwargs["data"]["set-param"], str)
+
+    request.do(
+        'xoxb-123',
+        'chat.postMessage',
+        {
+            'generator-param': (x for x in range(3))
+        }
+    )
+    args, kwargs = requests.post.call_args
+    assert requests.post.call_count == 4
+    assert 'https://slack.com/api/chat.postMessage' == args[0]
+    assert isinstance(kwargs["data"]["generator-param"], str)
+
+    request.do(
+        'xoxb-123',
+        'chat.postMessage',
+        {
+            'dict-param': {
+                'Dict': 'parameter'
+            }
+        }
+    )
+    args, kwargs = requests.post.call_args
+    assert requests.post.call_count == 5
+    assert 'https://slack.com/api/chat.postMessage' == args[0]
+    assert isinstance(kwargs["data"]["dict-param"], str)
+
+    request.do(
+        'xoxb-123',
+        'chat.postMessage',
+        {
+            'non-iterable': 123
+        }
+    )
+    args, kwargs = requests.post.call_args
+    assert requests.post.call_count == 6
+    assert 'https://slack.com/api/chat.postMessage' == args[0]
+    assert isinstance(kwargs["data"]["non-iterable"], int)


### PR DESCRIPTION
###  Summary

Allow iterable type request parameters to be serialized as JSON, in addition to lists and dicts. Add tests to cover new cases. Tuples, sets and generators will now also be serialized. This fixes issue #337 . 

If that's too wide a net to cast, I can narrow that down. Just let me know. :-)

### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).