### PR TITLE
save the user profile data within the User object

### DIFF
--- a/slackclient/server.py
+++ b/slackclient/server.py
@@ -207,7 +207,8 @@ class Server(object):
                              user["id"],
                              user["real_name"],
                              user["tz"],
-                             user["profile"]["email"])
+                             user["profile"]["email"],
+                             user["profile"])
 
     def send_to_websocket(self, data):
         """
@@ -281,8 +282,8 @@ class Server(object):
                     raise SlackConnectionError("Unable to send due to closed RTM websocket")
             return data.rstrip()
 
-    def attach_user(self, name, user_id, real_name, tz, email):
-        self.users.update({user_id: User(self, name, user_id, real_name, tz, email)})
+    def attach_user(self, name, user_id, real_name, tz, email, profile):
+        self.users.update({user_id: User(self, name, user_id, real_name, tz, email, profile)})
 
     def attach_channel(self, name, channel_id, members=None):
         if members is None:

--- a/slackclient/user.py
+++ b/slackclient/user.py
@@ -1,11 +1,12 @@
 class User(object):
-    def __init__(self, server, name, user_id, real_name, tz, email):
+    def __init__(self, server, name, user_id, real_name, tz, email, profile):
         self.tz = tz
         self.name = name
         self.real_name = real_name
         self.server = server
         self.id = user_id
         self.email = email
+        self.profile = profile
 
     def __eq__(self, compare_str):
         if compare_str in (self.id, self.name):

--- a/slackclient/version.py
+++ b/slackclient/version.py
@@ -1,2 +1,2 @@
 # see: http://legacy.python.org/dev/peps/pep-0440/#public-version-identifiers
-__version__ = '1.2.1'
+__version__ = '1.2.2'


### PR DESCRIPTION
###  Summary

Save the user profile data within the user object.

The [API changelog](https://api.slack.com/changelog/2017-09-the-one-about-usernames) from almost a year ago describes how @mentions are changing and we need to use the new model before September 12, 2018, but it's impossible to get at the necessary profile data with the present implementation.  This implementation isn't perfect (just shoving all the profile data into a dict in the User model), but it's backwards compatible and will allow us the ability to construct @mentions that will still function a month  (and some change) from now).

Considering the timeliness of the API change SOME measure is needed, even if not ideal, IMHO. 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).