### PR TITLE
Python 3.3 reached EOL in September of 2017

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dist: trusty
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 ; for quality analysis, use `tox -e flake8` or just `flake8 slackclient`
 ; to build the docs, use `tox -e docs`
 envlist=
-    py{27,33,34,35,36},
+    py{27,34,35,36},
     flake8,
     docs
 


### PR DESCRIPTION
This PR Removes 3.3 from travis' testing environments.

Travis is having issues running tests in Python 3.3, wheel has dropped support for it, and it's past it's end of life.

Travis errors:
https://travis-ci.org/slackapi/python-slackclient/jobs/424975836

https://www.python.org/dev/peps/pep-0398/#x-end-of-life
>End of Life: September 29, 2017