### PR TITLE
Enterprise ID does not always show up so checked for it

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
   "python.linting.pylintEnabled": false,
   "python.linting.flake8Enabled": true,
   "python.venvPath": "./venv",
-  "python.pythonPath": "${workspaceFolder}/venv/bin/python",
+  "python.pythonPath": "C:\\Users\\Micah Lyle\\envs\\sc\\Scripts\\python.exe",
   "python.formatting.provider": "black",
   "editor.formatOnSave": true,
 }

--- a/slackclient/client.py
+++ b/slackclient/client.py
@@ -106,11 +106,12 @@ class SlackClient(object):
             self.access_token_expires_at = expires_at
             # Call the developer's token update callback
             update_args = {
-                "enterprise_id": response_json["enterprise_id"],
                 "team_id": response_json["team_id"],
                 "access_token": response_json["access_token"],
-                "expires_in": response_json["expires_in"],
+                "expires_in": response_json["expires_in"]
             }
+            if "enterprise_id" in response_json:
+                update_args["enterprise_id"] = response_json["enterprise_id"]
             self.token_update_callback(update_args)
         else:
             raise TokenRefreshError("Token refresh failed")

--- a/slackclient/server.py
+++ b/slackclient/server.py
@@ -346,7 +346,8 @@ class Server(object):
 
             See here for more information on responses: https://api.slack.com/web
         """
-        response = self.api_requester.do(token, request, kwargs, timeout=timeout)
+        as_user = kwargs.pop("as_user", None)
+        response = self.api_requester.do(token, request, kwargs, as_user=as_user, timeout=timeout)
         response_json = json.loads(response.text)
         response_json["headers"] = dict(response.headers)
         return json.dumps(response_json)


### PR DESCRIPTION
###  Summary

Describe the goal of this PR. Mention any related Issue numbers.

Handles cases when enterprise_id is not available, like below:

```
    response = client.api_call(method="users.info", user=user_id)
  File "C:\Users\MICAHL~1\Envs\ch\lib\site-packages\slackclient\client.py", line 181, in api_call
    self.refresh_access_token()
  File "C:\Users\MICAHL~1\Envs\ch\lib\site-packages\slackclient\client.py", line 109, in refresh_access_token
    "enterprise_id": response_json["enterprise_id"],
KeyError: 'enterprise_id'
```

### Requirements (place an `x` in each `[ ]`)

* [x ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [ x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).