### PR TITLE
Update `files.upload` link in docs

### DIFF
--- a/docs-src/basic_usage.rst
+++ b/docs-src/basic_usage.rst
@@ -331,7 +331,7 @@ Uploading files
           title="Test upload"
       )
 
-See `users.list <https://api.slack.com/methods/files.upload>`_ for more info.
+See `files.upload <https://api.slack.com/methods/files.upload>`_ for more info.
 
 
 --------

--- a/docs/basic_usage.html
+++ b/docs/basic_usage.html
@@ -413,7 +413,7 @@ joined one by accident. This is how you leave a channel.</p>
     <span class="p">)</span>
 </pre></div>
 </div>
-<p>See <a class="reference external" href="https://api.slack.com/methods/files.upload">users.list</a> for more info.</p>
+<p>See <a class="reference external" href="https://api.slack.com/methods/files.upload">files.upload</a> for more info.</p>
 </div>
 <hr class="docutils" />
 <div class="section" id="web-api-rate-limits">


### PR DESCRIPTION
###  Summary

Fixes the `file.upload` link in the basic usage docs. Resolves #355.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).