### PR TITLE
Catch ConnectionResetError for Reconnect

### DIFF
--- a/slackclient/server.py
+++ b/slackclient/server.py
@@ -295,6 +295,15 @@ class Server(object):
                     raise SlackConnectionError(
                         "Unable to send due to closed RTM websocket"
                     )
+            except ConnectionResetError as e:
+                logging.debug("Connection Reset")
+                self.connected = False
+                if self.auto_reconnect:
+                    self.rtm_connect(reconnect=True)
+                else:
+                    raise SlackConnectionError(
+                        "Unable to send due to reset connection."
+                    )
             return data.rstrip()
 
     def attach_user(self, name, user_id, real_name, tz, email):


### PR DESCRIPTION
* Added ConnectionResetError to exceptions caught for possible reconnect.
* Modified logging message and error message to reflect Connection Reset.

###  Summary

This change fixes issue #336 by catching a ConnectionResetError and reconnecting if appropriate. 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).