### PR TITLE
Fixed deprecated warn call

### DIFF
--- a/slackclient/client.py
+++ b/slackclient/client.py
@@ -140,7 +140,7 @@ class SlackClient(object):
             self.server.rtm_connect(use_rtm_start=with_team_state, **kwargs)
             return self.server.connected
         except Exception:
-            LOG.warn("Failed RTM connect", exc_info=True)
+            LOG.warning("Failed RTM connect", exc_info=True)
             return False
 
     def api_call(self, method, timeout=None, **kwargs):


### PR DESCRIPTION
Replaced warn() with warning

###  Summary

This pull request fixes the issue described in 365

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).