### PR TITLE
Add 'users.setPhoto' to upload endpoints and handle 'image' attribute correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ python:
   - "3.5"
   - "3.6"
 install:
-  - travis_retry yes | pip uninstall pytest
   - travis_retry pip install -r requirements.txt
   - travis_retry pip install flake8
   - travis_retry pip install -r test_requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
   - "3.5"
   - "3.6"
 install:
-  - travis_retry pip uninstall pytest
+  - travis_retry yes | pip uninstall pytest
   - travis_retry pip install -r requirements.txt
   - travis_retry pip install flake8
   - travis_retry pip install -r test_requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "3.5"
   - "3.6"
 install:
+  - travis_retry pip uninstall pytest
   - travis_retry pip install -r requirements.txt
   - travis_retry pip install flake8
   - travis_retry pip install -r test_requirements.txt

--- a/slackclient/slackrequest.py
+++ b/slackclient/slackrequest.py
@@ -63,12 +63,15 @@ class SlackRequest(object):
         post_data = post_data or {}
 
         # Move singular file objects into `files`
-        upload_requests = ['files.upload']
+        upload_requests = ['files.upload', 'users.setPhoto']
 
         # Move file content into requests' `files` param
         files = None
         if request in upload_requests:
-            files = {'file': post_data.pop('file')} if 'file' in post_data else None
+            if 'file' in post_data:
+                files = {'file': post_data.pop('file')}
+            elif 'image' in post_data:
+                files = {'image': post_data.pop('image')}
 
         # Check for plural fields and convert them to comma-separated strings if needed
         for field in {'channels', 'users', 'types'} & set(post_data.keys()):

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,4 @@
-pytest<4
+pytest>3.6,<4
 codecov
 coverage
 mock

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,4 @@
-pytest>=3.6
+pytest<4
 codecov
 coverage
 mock

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,4 @@
-pytest>=3.0.0,<4
+pytest>=3.6
 codecov
 coverage
 mock

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,4 @@
-pytest<4
+pytest>=3.0.0,<4
 codecov
 coverage
 mock

--- a/tests/test_slackrequest.py
+++ b/tests/test_slackrequest.py
@@ -86,6 +86,19 @@ def test_post_file(mocker):
     assert {'filename': 'slack_logo.png'} == kwargs['data']
     assert kwargs['files'] is not None
 
+def test_upload_image(mocker):
+    requests = mocker.patch('slackclient.slackrequest.requests')
+    request = SlackRequest()
+
+    request.do('xoxb-123',
+               'users.setPhoto',
+               {'as_user': True,'image': open(os.path.join('.', 'tests', 'data', 'slack_logo.png'), 'rb')})
+    args, kwargs = requests.post.call_args
+
+    assert requests.post.call_count == 1
+    assert 'https://slack.com/api/users.setPhoto' == args[0]
+    assert {'as_user': True} == kwargs['data']
+    assert kwargs['files'] is not None
 
 def test_get_file(mocker):
     requests = mocker.patch('slackclient.slackrequest.requests')


### PR DESCRIPTION
###  Summary

Fixes #378 by adding 'users.setPhoto' to the `upload_requests` array and handling the `image` attribute similarly to how `file` is passed to Requests (as non-JSON bytes).

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).