### PR TITLE
Lock websocket-client version: temp fix for #385

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(name='slackclient',
       keywords='slack slack-web slack-rtm chat chatbots bots chatops',
       packages=find_packages(exclude=['docs', 'docs-src', 'tests']),
       install_requires=[
-          'websocket-client >=0.35, <1.0a0',
+          'websocket-client >=0.35, <0.55.0',
           'requests >=2.11, <3.0a0',
           'six >=1.10, <2.0a0',
       ])


### PR DESCRIPTION
###  Summary
This is a temporary fix to resolve issues with the most recent `websocket-client` 0.55.0 release.

Related Issues:
https://github.com/slackapi/python-slackclient/issues/385
https://github.com/slackapi/python-slackclient/issues/386

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).