### PR TITLE
Remove unneeded apostrophe

### DIFF
--- a/docs-src/basic_usage.rst
+++ b/docs-src/basic_usage.rst
@@ -167,7 +167,7 @@ article for more information.
 Updating the content of a message
 ----------------------------------
 Let's say you have a bot which posts the status of a request. When that request
-is updated, you'll want to update the message to reflect it's state. Or your user
+is updated, you'll want to update the message to reflect its state. Or your user
 might want to fix a typo or change some wording. This is how you'll make those changes.
 
 .. code-block:: python


### PR DESCRIPTION
###  Summary

A possessive belonging to an "it" doesn't need an apostrophe. Don't believe me? Ask [the Oatmeal](http://theoatmeal.com/comics/apostrophe) (look for the velociraptor)!

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).