### PR TITLE
Return an empty dict when response is empty instead of throwing an error

### DIFF
--- a/slackclient/server.py
+++ b/slackclient/server.py
@@ -347,7 +347,10 @@ class Server(object):
             See here for more information on responses: https://api.slack.com/web
         """
         response = self.api_requester.do(token, request, kwargs, timeout=timeout)
-        response_json = json.loads(response.text)
+        response_json = {}
+        resp_text = response.text
+        if resp_text:
+            response_json = json.loads(resp_text)
         response_json["headers"] = dict(response.headers)
         return json.dumps(response_json)
 

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,6 +2,6 @@ pytest<4
 codecov
 coverage
 mock
-pytest-cov
+pytest-cov>=2.4.0,<2.6
 pytest-mock
 responses

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -44,6 +44,25 @@ def test_server_connect(rtm_start_fixture):
             ]
 
 
+def test_api_call_for_empty_slack_responses(server):
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            responses.POST,
+            "https://slack.com/api/chat.postMessage",
+            status=429,
+            headers={"Retry-After": "1"},
+        )
+
+        response_received = server.api_call("token", "chat.postMessage")
+        chat_postMessage_response = rsps.calls[0].response
+
+        assert chat_postMessage_response.text == ""
+        expected_response = (
+            '{"headers": {"Content-Type": "text/plain", "Retry-After": "1"}}'
+        )
+        assert response_received == expected_response
+
+
 def test_server_is_hashable(server):
     server_map = {server: server.token}
     assert server_map[server] == 'xoxp-1234123412341234-12341234-1234'

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -57,10 +57,10 @@ def test_api_call_for_empty_slack_responses(server):
         chat_postMessage_response = rsps.calls[0].response
 
         assert chat_postMessage_response.text == ""
-        expected_response = (
-            '{"headers": {"Content-Type": "text/plain", "Retry-After": "1"}}'
-        )
-        assert response_received == expected_response
+        expected_response = {
+            "headers": {"Content-Type": "text/plain", "Retry-After": "1"}
+        }
+        assert json.loads(response_received) == expected_response
 
 
 def test_server_is_hashable(server):


### PR DESCRIPTION
###  Summary

This issues fixes #169.

### Requirements
* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).