### PR TITLE
Modify package identifier in user agent to match v1.x identifier

### DIFF
--- a/slack/web/base_client.py
+++ b/slack/web/base_client.py
@@ -219,10 +219,10 @@ class BaseClient:
 
         Returns:
             The user agent string.
-            e.g. 'Python/3.6.7 slack/2.0.0 Darwin/17.7.0'
+            e.g. 'Python/3.6.7 slackclient/2.0.0 Darwin/17.7.0'
         """
         # __name__ returns all classes, we only want the client
-        client = "{0}/{1}".format(__name__.split(".")[0], ver.__version__)
+        client = "{0}/{1}".format("slackclient", ver.__version__)
         python_version = "Python/{v.major}.{v.minor}.{v.micro}".format(
             v=sys.version_info
         )


### PR DESCRIPTION
###  Summary

Since `v2.0.0`, the package identifier in each request (embedded in the `User-Agent` header) changed from `slackclient` to `slack`. This change was not intentional, it was incidental on the fact that the code read the identifier from the module name using the magic variable `__name__`.

That change introduces issues in how Slack measures the usage of this tool. `slack` lacks the uniqueness, since other tools including the Desktop apps report themselves as `slack`. This forces classification of a request to require knowing the entire User Agent header to look for `python` alongside `slack` to distinguish. Ideally, the parsing logic can break the User Agent string on spaces, and classify each portion separately. It also creates a discontinuity so we cannot measure v2.x next to v1.x and other languages as easily. 

This change reverts the incidental change, to a more intentional one that preserves `slackclient`. One disadvantage of this solution is that the string "slackclient" can be seen as not self-descriptive - "What is slackclient? At least `slack` reflects the name of the Python module.". I think the reflecting the name of the module is not as useful as reflecting the name of the package. And to that end, "slackclient" is the name this package is distributed as. It's not perfect, and if we could start all over we would likely choose something different, but I still think its worth correcting the current issue now and looking at what it might take to rename this package in a separate issue (if that's something we want to do).

This change now includes unit test to verify that the language and package identifier are present in the User Agent.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).