### PR TITLE
modified dnd.teamInfo to have a required Users argument

### DIFF
--- a/slack/web/client.py
+++ b/slack/web/client.py
@@ -573,8 +573,12 @@ class WebClient(BaseClient):
         kwargs.update({"num_minutes": num_minutes})
         return self.api_call("dnd.setSnooze", http_verb="GET", params=kwargs)
 
-    def dnd_teamInfo(self, **kwargs) -> SlackResponse:
-        """Retrieves the Do Not Disturb status for users on a team."""
+    def dnd_teamInfo(self, *, users: str,**kwargs) -> SlackResponse:
+        """Retrieves the Do Not Disturb status for users on a team.
+        Args:
+            users (str): Comma-seperated list of users to fetch Status for. e.g. 'U1234,W4567'
+        """
+        kwargs.update({"users": users})
         return self.api_call("dnd.teamInfo", http_verb="GET", params=kwargs)
 
     def emoji_list(self, **kwargs) -> SlackResponse:


### PR DESCRIPTION
###  Summary

As per changelog June 2019, this PR adds `users` as a required argument to `dnd.teamInfo`

>  As announced on March 25, the dnd.teamInfo method now requires the users parameter. An explicit list of users helps you, and us, avoid slow API calls.