### PR TITLE
Fixing 415 - Converting the typing function to async

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ coverage.xml
 .pytest_cache/
 .python-version
 pip
+.mypy_cache/

--- a/slack/rtm/client.py
+++ b/slack/rtm/client.py
@@ -131,7 +131,6 @@ class RTMClient(object):
         self._last_message_id = 0
         self._connection_attempts = 0
         self._stopped = False
-        self._event_queue = asyncio.Queue(loop=self._event_loop)
 
     @staticmethod
     def run_on(*, event: str):
@@ -187,12 +186,12 @@ class RTMClient(object):
             for s in signals:
                 self._event_loop.add_signal_handler(s, self.stop)
 
-        if self.run_async:
-            return asyncio.ensure_future(
-                self._connect_and_read(), loop=self._event_loop
-            )
+        future = asyncio.ensure_future(self._connect_and_read(), loop=self._event_loop)
 
-        return self._event_loop.run_until_complete(self._connect_and_read())
+        if self.run_async:
+            return future
+
+        return self._event_loop.run_until_complete(future)
 
     def stop(self):
         """Closes the websocket connection and ensures it won't reconnect."""

--- a/slack/web/base_client.py
+++ b/slack/web/base_client.py
@@ -108,14 +108,12 @@ class BaseClient:
             form_data = aiohttp.FormData()
             for k, v in files.items():
                 if isinstance(v, str):
-                    # TODO: This should be opened with a context manager.
                     form_data.add_field(k, open(v, "rb"))
                 else:
                     form_data.add_field(k, v)
 
             if data is not None:
                 for k, v in data.items():
-                    # TODO: We should not be casting this to a string. Test why this is here.
                     form_data.add_field(k, str(v))
 
             data = form_data

--- a/slack/web/base_client.py
+++ b/slack/web/base_client.py
@@ -44,11 +44,6 @@ class BaseClient:
         self._event_loop = loop
 
     def _set_event_loop(self):
-        """Sets the Event loop.
-
-        # TODO: Document why it's neccessary to create a new_event_loop.
-        # During testing I found that get_event_loop doesn't work from new Threads.
-        """
         if self.run_async:
             return asyncio.get_event_loop()
         else:

--- a/slack/web/client.py
+++ b/slack/web/client.py
@@ -656,10 +656,9 @@ class WebClient(BaseClient):
 
         if file:
             return self.api_call("files.upload", files={"file": file}, data=kwargs)
-        elif content:
-            data = kwargs.copy()
-            data.update({"content": content})
-            return self.api_call("files.upload", data=data)
+        data = kwargs.copy()
+        data.update({"content": content})
+        return self.api_call("files.upload", data=data)
 
     def groups_archive(self, *, channel: str, **kwargs) -> SlackResponse:
         """Archives a private channel.

--- a/tests/rtm/test_rtm_client.py
+++ b/tests/rtm/test_rtm_client.py
@@ -2,6 +2,7 @@
 import collections
 import unittest
 from unittest import mock
+import asyncio
 
 # Internal Imports
 import slack
@@ -65,7 +66,8 @@ class TestRTMClient(unittest.TestCase):
 
     def test_send_over_websocket_raises_when_not_connected(self):
         with self.assertRaises(e.SlackClientError) as context:
-            self.client.send_over_websocket(payload={})
+            loop = asyncio.get_event_loop()
+            loop.run_until_complete(self.client.send_over_websocket(payload={}))
 
         expected_error = "Websocket connection is closed."
         error = str(context.exception)

--- a/tests/rtm/test_rtm_client_functional.py
+++ b/tests/rtm/test_rtm_client_functional.py
@@ -41,7 +41,7 @@ class TestRTMClientFunctional(unittest.TestCase):
             async for msg in ws:
                 await ws.send_json({"type": "message", "message_sent": msg.json()})
         finally:
-            request.app["websockets"].discard(ws)
+            request.app["websockets"].remove(ws)
         return ws
 
     async def on_shutdown(self, app):
@@ -170,9 +170,9 @@ class TestRTMClientFunctional(unittest.TestCase):
 
     def test_ping_sends_expected_message(self, mock_rtm_response):
         @slack.RTMClient.run_on(event="open")
-        def ping_message(**payload):
+        async def ping_message(**payload):
             rtm_client = payload["rtm_client"]
-            rtm_client.ping()
+            await rtm_client.ping()
 
         @slack.RTMClient.run_on(event="message")
         def check_message(**payload):
@@ -185,9 +185,9 @@ class TestRTMClientFunctional(unittest.TestCase):
 
     def test_typing_sends_expected_message(self, mock_rtm_response):
         @slack.RTMClient.run_on(event="open")
-        def typing_message(**payload):
+        async def typing_message(**payload):
             rtm_client = payload["rtm_client"]
-            rtm_client.typing(channel="C01234567")
+            await rtm_client.typing(channel="C01234567")
 
         @slack.RTMClient.run_on(event="message")
         def check_message(**payload):


### PR DESCRIPTION
###  Summary
When using `RTMClient#typing()`, the typing indicator was not being sent immediately because the function was not asynchronous. This caused the erroneous behavior described in #415. In order to immediately send any data over the websocket with aiohttp we must use an async function.

This PR changes both `#typing()` and `#ping()` functions on the `RTMClient` class into async functions.

Here's an example of what this would look like implemented:
```Python
@slack.RTMClient.run_on(event="open")
async def typing_message(**payload):
    rtm_client = payload["rtm_client"]
    await rtm_client.typing(channel="C01234567")
```

It's a minor but still backwards-incompatible change.

### Requirements
* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).