### PR TITLE
Issue 429 - Allow slackClient 2+ with aiohttp lib to use existing event loop. (Fix git config)

### DIFF
--- a/slack/web/base_client.py
+++ b/slack/web/base_client.py
@@ -126,7 +126,6 @@ class BaseClient:
 
         future = asyncio.ensure_future(
             self._send(http_verb=http_verb, api_url=api_url, req_args=req_args),
-            loop=self._event_loop,
         )
 
         if self.run_async:
@@ -202,7 +201,7 @@ class BaseClient:
                     "status_code": res.status,
                 }
         async with aiohttp.ClientSession(
-            loop=self._event_loop, timeout=aiohttp.ClientTimeout(total=self.timeout)
+            timeout=aiohttp.ClientTimeout(total=self.timeout)
         ) as session:
             async with session.request(http_verb, api_url, **req_args) as res:
                 self._logger.debug("Ran the request with a new session.")


### PR DESCRIPTION
###  Summary

Related to issue: [429](https://github.com/slackapi/python-slackclient/issues/429)

This PR is to enable the use of aiohttp and the existing event loop in a framework like jupyter notebook or sanic framework.

Slack Client is using another event loop, not using the parent loop.

Modified running task async and aiohttp library to automatically detect event loop.

### Tested
Within framework [sanic]()

With uvloop



### Requirements (place an `x` in each `[ ]`)

* [ ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).