### PR TITLE
Use kwarg for web_client.im_open in tutorial docs

### DIFF
--- a/tutorial/03-responding-to-slack-events.md
+++ b/tutorial/03-responding-to-slack-events.md
@@ -89,7 +89,7 @@ def onboarding_message(**payload):
     web_client = payload["web_client"]
 
     # Open a DM with the new user.
-    response = web_client.im_open(user_id)
+    response = web_client.im_open(user=user_id)
     channel = response["channel"]["id"]
 
     # Post the onboarding message.


### PR DESCRIPTION
###  Summary

The `WebClient` methods require keyword arguments, but the tutorial documentation omits the `user` keyword argument to `WebClient.im_open`, which might cause someone following the tutorial to encounter an error like this.
```python
TypeError: im_open() takes 1 positional argument but 2 were given
```

This PR resolves that by adding the `user` keyword argument.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).