### PR TITLE
Update BlockAttachment to not send invalid JSON due to fields attribute

### DIFF
--- a/slack/web/classes/attachments.py
+++ b/slack/web/classes/attachments.py
@@ -211,9 +211,14 @@ class BlockAttachment(Attachment):
         super().__init__(text="", color=color)
         self.blocks = list(blocks)
 
+    @JsonValidator("fields attribute cannot be populated on BlockAttachment")
+    def fields_attribute_absent(self):
+        return not self.fields
+
     def to_dict(self) -> dict:
         json = super().to_dict()
         json.update({"blocks": extract_json(self.blocks)})
+        del json["fields"]  # cannot supply fields and blocks at the same time
         return json
 
 

--- a/tests/web/classes/test_attachments.py
+++ b/tests/web/classes/test_attachments.py
@@ -2,8 +2,10 @@ import unittest
 
 from slack.errors import SlackObjectFormationError
 from slack.web.classes.actions import ActionButton, ActionLinkButton
+from slack.web.classes.blocks import SectionBlock, ImageBlock
 from slack.web.classes.attachments import (
     Attachment,
+    BlockAttachment,
     AttachmentField,
     InteractiveAttachment,
 )
@@ -206,3 +208,16 @@ class InteractiveAttachmentTests(unittest.TestCase):
             InteractiveAttachment(
                 text="some text", callback_id="abc123", actions=actions
             ).to_dict(),
+
+
+class BlockAttachmentTests(unittest.TestCase):
+    def test_basic_json(self):
+        blocks = [
+            SectionBlock(text="Some text"),
+            ImageBlock(image_url="image.jpg", alt_text="an image")
+        ]
+
+        self.assertDictEqual(
+            BlockAttachment(blocks=blocks).to_dict(), {"blocks": [b.to_dict() for b in blocks]}
+        )
+


### PR DESCRIPTION
###  Summary

Fixes a bug in #400; the base Attachment class that BlockAttachment inherits from will populate the `fields` attribute with an empty list, which then gets sent in the JSON to Slack. That makes the JSON invalid, meaning the BlockAttachment class as it is now cannot be used without manually adjusting the JSON/dict returned.

This PR updates the class, as well as adds a test that would have caught this.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).