### PR TITLE
Return callback from `RTMClient.run_on`

### DIFF
--- a/slack/rtm/client.py
+++ b/slack/rtm/client.py
@@ -141,6 +141,7 @@ class RTMClient(object):
 
         def decorator(callback):
             RTMClient.on(event=event, callback=callback)
+            return callback
 
         return decorator
 

--- a/tests/rtm/test_rtm_client.py
+++ b/tests/rtm/test_rtm_client.py
@@ -19,11 +19,11 @@ class TestRTMClient(unittest.TestCase):
 
     def test_run_on_returns_callback(self):
         @slack.RTMClient.run_on(event="message")
-        def fn_used_elsewhere(**payload):
+        def fn_used_elsewhere(**_unusedPayload):
             pass
         
-        self.assertTrue(fn_used_elsewhere != None)
-        self.assertTrue(fn_used_elsewhere.__name__ == "fn_used_elsewhere")
+        self.assertIsNotNone(fn_used_elsewhere)
+        self.assertEqual(fn_used_elsewhere.__name__, "fn_used_elsewhere")
 
     def test_run_on_annotation_sets_callbacks(self):
         @slack.RTMClient.run_on(event="message")

--- a/tests/rtm/test_rtm_client.py
+++ b/tests/rtm/test_rtm_client.py
@@ -17,6 +17,14 @@ class TestRTMClient(unittest.TestCase):
     def tearDown(self):
         slack.RTMClient._callbacks = collections.defaultdict(list)
 
+    def test_run_on_returns_callback(self):
+        @slack.RTMClient.run_on(event="message")
+        def fn_used_elsewhere(**payload):
+            pass
+        
+        self.assertTrue(fn_used_elsewhere != None)
+        self.assertTrue(fn_used_elsewhere.__name__ == "fn_used_elsewhere")
+
     def test_run_on_annotation_sets_callbacks(self):
         @slack.RTMClient.run_on(event="message")
         def say_run_on(**payload):

--- a/tests/rtm/test_rtm_client.py
+++ b/tests/rtm/test_rtm_client.py
@@ -19,7 +19,7 @@ class TestRTMClient(unittest.TestCase):
 
     def test_run_on_returns_callback(self):
         @slack.RTMClient.run_on(event="message")
-        def fn_used_elsewhere(**_unusedPayload):
+        def fn_used_elsewhere(**_unused_payload):
             pass
         
         self.assertIsNotNone(fn_used_elsewhere)


### PR DESCRIPTION
###  Summary

Returns the callback passed into `RTMClient.run_on` so that it can be called elsewhere. For example:

```python
@RTMClient.run_on("message")
def magic(**payload):
  print('🔮')

magic()
# before PR -> errors because `magic` is `None`
# after PR  -> prints 🔮
```

> Fixes #485.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).