### PR TITLE
Fix link to Auth Guide in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The **Python slackclient** allows interaction with:
 
 If you want to use our [Events API][events-docs], please check the [Slack Events API adapter for Python][python-slack-events-api].
 
-Details on the Tokens and Authentication can be found in our [Auth Guide][https://slack.dev/python-slackclient/auth.html].
+Details on the Tokens and Authentication can be found in our [Auth Guide](https://slack.dev/python-slackclient/auth.html).
 
 ## Table of contents
 


### PR DESCRIPTION
###  Summary

Fix link to Auth Guide in readme
Before:
<img width="886" alt="Screenshot 2019-08-09 17 41 44" src="https://user-images.githubusercontent.com/1268088/62815369-1252f780-bacd-11e9-8dbb-fb72a2921a96.png">

[After](https://github.com/asherf/python-slackclient/tree/readme):
<img width="809" alt="Screenshot 2019-08-09 17 42 00" src="https://user-images.githubusercontent.com/1268088/62815373-15e67e80-bacd-11e9-9469-7a1e3b5bf46b.png">

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).