### PR TITLE
bugfix for value length in button elements

### DIFF
--- a/slack/web/classes/elements.py
+++ b/slack/web/classes/elements.py
@@ -78,7 +78,7 @@ class ButtonElement(InteractiveElement):
         return super().attributes.union({"style", "value"})
 
     text_max_length = 75
-    value_max_length = 75
+    value_max_length = 2000
 
     def __init__(
         self,

--- a/tests/web/classes/test_elements.py
+++ b/tests/web/classes/test_elements.py
@@ -65,7 +65,7 @@ class ButtonElementTests(unittest.TestCase):
     def test_value_length(self):
         with self.assertRaises(SlackObjectFormationError):
             ButtonElement(
-                text="Button", action_id="button", value=STRING_301_CHARS
+                text="Button", action_id="button", value=STRING_3001_CHARS
             ).to_dict()
 
     def test_invalid_style(self):


### PR DESCRIPTION
###  Summary

Bugfix for max value length in button elements. Documentation indicates 2000, the code however permits no more than 75 characters.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).