### PR TITLE
Improve a code snippet on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ In our example below, we watch for a [message event][message-event] that contain
         data = payload['data']
         web_client = payload['web_client']
         rtm_client = payload['rtm_client']
-        if 'Hello' in data['text']:
+        if 'Hello' in data.get('text', []):
             channel_id = data['channel']
             thread_ts = data['ts']
             user = data['user']


### PR DESCRIPTION
###  Summary

This pull request improves the RTM code snippet on README. Currently, the code fails every time a bot message is posted with KeyError as below:

```
(omitted)
  File "app.py", line 11, in say_hello
    if data and 'Hello' in data['text']:
KeyError: 'text'
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).