### PR TITLE
Fix Web Client custom iterator

### DIFF
--- a/slack/web/slack_response.py
+++ b/slack/web/slack_response.py
@@ -70,6 +70,7 @@ class SlackResponse(object):
         self.data = data
         self.headers = headers
         self.status_code = status_code
+        self._initial_data = data
         self._client = client
         self._logger = logging.getLogger(__name__)
 
@@ -101,6 +102,7 @@ class SlackResponse(object):
             (SlackResponse) self
         """
         self._iteration = 0
+        self.data = self._initial_data
         return self
 
     def __next__(self):


### PR DESCRIPTION
###  Summary

For Web Client, since `SlackResponse` class overrides an initial response data when iterating through the response object, it only returns the last fetched response data when it's iterated twice.

```py
import slack

client = slack.WebClient(token='redacted')
response = client.channels_list(limit=50)

print('#### 1st iteration ####')

for i in response:
    print(i['channels'][0]['id'])

print('#### 2nd iteration ####')

for i in response:
    print(i['channels'][0]['id'])
```

### Actual result
```sh
#### 1st iteration ####
C9A81JQQ4
CB2LQDJTB
CB34D9SQ3
CB3BF4953
CB48SJH1V
#### 2nd iteration ####
CB48SJH1V
```

### Expected result
```sh
#### 1st iteration ####
C9A81JQQ4
CB2LQDJTB
CB34D9SQ3
CB3BF4953
CB48SJH1V
#### 2nd iteration ####
C9A81JQQ4
CB2LQDJTB
CB34D9SQ3
CB3BF4953
CB48SJH1V
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).