### PR TITLE
:facepalm: Fixing issues around Oauth and SlackApiErrors

### DIFF
--- a/slack/errors.py
+++ b/slack/errors.py
@@ -21,7 +21,16 @@ class SlackRequestError(SlackClientError):
 
 
 class SlackApiError(SlackClientError):
-    """Error raised when Slack does not send the expected response."""
+    """Error raised when Slack does not send the expected response.
+
+    Attributes:
+        response (SlackResponse): The SlackResponse object containing all of the data sent back from the API.
+
+    Note:
+        The message (str) passed into the exception is used when
+        a user converts the exception to a str.
+        i.e. str(SlackApiError("This text will be sent as a string."))
+    """
 
     def __init__(self, message, response):
         msg = f"{message}\nThe server responded with: {response}"

--- a/slack/web/client.py
+++ b/slack/web/client.py
@@ -1124,8 +1124,12 @@ class WebClient(BaseClient):
             client_secret (str): Issued when you created your application. e.g. '33fea0113f5b1'
             code (str): The code param returned via the OAuth callback. e.g. 'ccdaa72ad'
         """
-        headers = {"client_id": client_id, "client_secret": client_secret, "code": code}
-        return self.api_call("oauth.access", data=kwargs, headers=headers)
+        kwargs.update({"code": code})
+        return self.api_call(
+            "oauth.access",
+            data=kwargs,
+            auth={"client_id": client_id, "client_secret": client_secret},
+        )
 
     def pins_add(self, *, channel: str, **kwargs) -> Union[Future, SlackResponse]:
         """Pins an item to a channel.

--- a/slack/web/slack_response.py
+++ b/slack/web/slack_response.py
@@ -173,7 +173,7 @@ class SlackResponse(object):
             self._logger.debug("Received the following response: %s", self.data)
             return self
         msg = "The request to the Slack API failed."
-        raise e.SlackApiError(message=msg, response=self.data)
+        raise e.SlackApiError(message=msg, response=self)
 
     @staticmethod
     def _next_cursor_is_present(data):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -16,6 +16,7 @@ def fake_req_args(headers=ANY, data=ANY, params=ANY, json=ANY):
         "json": json,
         "ssl": ANY,
         "proxy": ANY,
+        "auth": ANY,
     }
     return req_args
 
@@ -29,6 +30,7 @@ def fake_send_req_args(headers=ANY, data=ANY, params=ANY, json=ANY):
         "ssl": ANY,
         "proxy": ANY,
         "files": ANY,
+        "auth": ANY,
     }
     return req_args
 


### PR DESCRIPTION
###  Summary
Fixing https://github.com/slackapi/python-slackclient/issues/481 by properly passing oauth params with `aiohttp.BasicAuth`.

Fixing https://github.com/slackapi/python-slackclient/issues/436 by returning the entire SlackResponse in SlackApiError's.

### Requirements (place an `x` in each `[ ]`)
* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).