### PR TITLE
New Views API & Updates for internal request method

### DIFF
--- a/slack/rtm/client.py
+++ b/slack/rtm/client.py
@@ -323,7 +323,6 @@ class RTMClient(object):
             try:
                 self._connection_attempts += 1
                 async with aiohttp.ClientSession(
-                    loop=self._event_loop,
                     timeout=aiohttp.ClientTimeout(total=self.timeout),
                 ) as session:
                     self._session = session

--- a/slack/web/base_client.py
+++ b/slack/web/base_client.py
@@ -250,7 +250,6 @@ class BaseClient:
             session = self.session
         else:
             session = aiohttp.ClientSession(
-                loop=self._event_loop,
                 timeout=aiohttp.ClientTimeout(total=self.timeout),
                 auth=req_args.pop("auth", None),
             )

--- a/slack/web/client.py
+++ b/slack/web/client.py
@@ -1577,3 +1577,18 @@ class WebClient(BaseClient):
             raise e.SlackRequestError("Either view_id or external_id is required.")
 
         return self.api_call("views.update", json=kwargs)
+
+    def views_publish(
+        self, *, user_id: str, view: dict, **kwargs
+    ) -> Union[Future, SlackResponse]:
+        """Publish a static view for a User.
+        Create or update the view that comprises an
+        app's Home tab (https://api.slack.com/surfaces/tabs)
+        for a specific user.
+        Args:
+            user_id (str): id of the user you want publish a view to.
+                e.g. 'U0BPQUNTA'
+            view (dict): The view payload.
+        """
+        kwargs.update({"user_id": user_id, "view": view})
+        return self.api_call("views.publish", json=kwargs)


### PR DESCRIPTION
###  Summary
Adding new `views.publish` API.

Some responses don't return json. Correcting initial assumption. This fixes #493 & #535

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).