### PR TITLE
Fix regression in v2.3.0

### DIFF
--- a/slack/web/base_client.py
+++ b/slack/web/base_client.py
@@ -246,7 +246,8 @@ class BaseClient:
             A dictionary of the response data.
         """
         session = None
-        if self.session and not self.session.closed:
+        use_running_session = self.session and not self.session.closed
+        if use_running_session:
             session = self.session
         else:
             session = aiohttp.ClientSession(
@@ -265,7 +266,8 @@ class BaseClient:
                 )
             response = {"data": data, "headers": res.headers, "status_code": res.status}
 
-        await session.close()
+        if not use_running_session:
+            await session.close()
         return response
 
     @staticmethod


### PR DESCRIPTION
Make sure we do not close the running session

We must only close the temporary session used for the request.

Fixes: 854920dfb2a2

Signed-off-by: Fatih Acar <f.acar@criteo.com>

###  Summary

Latest release (v2.3.0) introduced a regression which make our slack app crash.
The associated traceback looks like:

```
Traceback (most recent call last):
  File "/home/f.acar/hwinfo-slackbot/venv/lib64/python3.6/site-packages/slack/rtm/client.py", line 334, in _connect_and_read
    proxy=self.proxy,
  File "/home/f.acar/hwinfo-slackbot/venv/lib64/python3.6/site-packages/aiohttp/client.py", line 1012, in __aenter__
    self._resp = await self._coro
  File "/home/f.acar/hwinfo-slackbot/venv/lib64/python3.6/site-packages/aiohttp/client.py", line 728, in _ws_connect
    proxy_headers=proxy_headers)
  File "/home/f.acar/hwinfo-slackbot/venv/lib64/python3.6/site-packages/aiohttp/client.py", line 357, in _request
    raise RuntimeError('Session is closed')
RuntimeError: Session is closed
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).