### PR TITLE
Fixed 'iteracting' typo in library file headers

### DIFF
--- a/slack/rtm/client.py
+++ b/slack/rtm/client.py
@@ -1,4 +1,4 @@
-"""A Python module for iteracting with Slack's RTM API."""
+"""A Python module for interacting with Slack's RTM API."""
 
 # Standard Imports
 import os

--- a/slack/web/base_client.py
+++ b/slack/web/base_client.py
@@ -1,4 +1,4 @@
-"""A Python module for iteracting with Slack's Web API."""
+"""A Python module for interacting with Slack's Web API."""
 
 # Standard Imports
 from urllib.parse import urljoin

--- a/slack/web/client.py
+++ b/slack/web/client.py
@@ -1,4 +1,4 @@
-"""A Python module for iteracting with Slack's Web API."""
+"""A Python module for interacting with Slack's Web API."""
 
 # Standard Imports
 from typing import Union, List

--- a/slack/web/slack_response.py
+++ b/slack/web/slack_response.py
@@ -1,4 +1,4 @@
-"""A Python module for iteracting and consuming responses from Slack."""
+"""A Python module for interacting and consuming responses from Slack."""
 
 # Standard Imports
 import logging


### PR DESCRIPTION
###  Summary

Several python files in the library share a common commented header with a typo. This PR corrects from 
"""A Python module for iteracting with Slack's RTM API."""
to
"""A Python module for interacting with Slack's RTM API."""

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).