### PR TITLE
Update docs/conversations.html - typo in API reference

### DIFF
--- a/docs/conversations.html
+++ b/docs/conversations.html
@@ -294,7 +294,7 @@
 <span class="n">client</span> <span class="o">=</span> <span class="n">slack</span><span class="o">.</span><span class="n">WebClient</span><span class="p">(</span><span class="n">slack_token</span><span class="p">)</span>
 
 <span class="n">client</span><span class="o">.</span><span class="n">conversations_list</span><span class="p">(</span>
-  <span class="n">types</span><span class="o">=</span><span class="s2">&quot;public_channels, private_channels&quot;</span>
+  <span class="n">types</span><span class="o">=</span><span class="s2">&quot;public_channel, private_channel&quot;</span>
 <span class="p">)</span>
 </pre></div>
 </div>


### PR DESCRIPTION
###  Summary

Typo in conversations reference page. In example for `conversations_list`, example given for `types` parameter is 
`"public_channels, private_channels"`
Whereas it should be 
`"public_channel, private_channel"`


### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).