### PR TITLE
Strip token string parameters of whitespace

### DIFF
--- a/slack/rtm/client.py
+++ b/slack/rtm/client.py
@@ -116,7 +116,7 @@ class RTMClient(object):
         loop: Optional[asyncio.AbstractEventLoop] = None,
         headers: Optional[dict] = {},
     ):
-        self.token = token
+        self.token = token.strip()
         self.run_async = run_async
         self.auto_reconnect = auto_reconnect
         self.ssl = ssl

--- a/slack/web/base_client.py
+++ b/slack/web/base_client.py
@@ -35,7 +35,7 @@ class BaseClient:
         session=None,
         headers: Optional[dict] = None,
     ):
-        self.token = token
+        self.token = token.strip()
         self.base_url = base_url
         self.timeout = timeout
         self.ssl = ssl


### PR DESCRIPTION
###  Summary

If tokens contain whitespace, API calls fail in a confusing manner. See #598.

This change simply strips whitespace from tokens, to avoid confusing failures.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).