### PR TITLE
Merge pull request #604 from scotto-at-niche/fix_retrieve_typo

### DIFF
--- a/slack/rtm/client.py
+++ b/slack/rtm/client.py
@@ -182,7 +182,7 @@ class RTMClient(object):
         is lost unintentionally or an exception is thrown.
 
         Raises:
-            SlackApiError: Unable to retreive RTM URL from Slack.
+            SlackApiError: Unable to retrieve RTM URL from Slack.
         """
         # TODO: Add Windows support for graceful shutdowns.
         if os.name != "nt":
@@ -305,7 +305,7 @@ class RTMClient(object):
         return self._last_message_id
 
     async def _connect_and_read(self):
-        """Retreives the WS url and connects to Slack's RTM API.
+        """Retrieves the WS url and connects to Slack's RTM API.
 
         Makes an authenticated call to Slack's Web API to retrieve
         a websocket URL. Then connects to the message server and
@@ -316,7 +316,7 @@ class RTMClient(object):
         is lost unintentionally or an exception is thrown.
 
         Raises:
-            SlackApiError: Unable to retreive RTM URL from Slack.
+            SlackApiError: Unable to retrieve RTM URL from Slack.
             websockets.exceptions: Errors thrown by the 'websockets' library.
         """
         while not self._stopped:
@@ -326,7 +326,7 @@ class RTMClient(object):
                     timeout=aiohttp.ClientTimeout(total=self.timeout)
                 ) as session:
                     self._session = session
-                    url, data = await self._retreive_websocket_info()
+                    url, data = await self._retrieve_websocket_info()
                     async with session.ws_connect(
                         url,
                         heartbeat=self.ping_interval,
@@ -464,8 +464,8 @@ class RTMClient(object):
 
             future.result()
 
-    async def _retreive_websocket_info(self):
-        """Retreives the WebSocket info from Slack.
+    async def _retrieve_websocket_info(self):
+        """Retrieves the WebSocket info from Slack.
 
         Returns:
             A tuple of websocket information.
@@ -483,7 +483,7 @@ class RTMClient(object):
             )
 
         Raises:
-            SlackApiError: Unable to retreive RTM URL from Slack.
+            SlackApiError: Unable to retrieve RTM URL from Slack.
         """
         if self._web_client is None:
             self._web_client = WebClient(
@@ -503,7 +503,7 @@ class RTMClient(object):
             resp = await self._web_client.rtm_connect()
         url = resp.get("url")
         if url is None:
-            msg = "Unable to retreive RTM URL from Slack."
+            msg = "Unable to retrieve RTM URL from Slack."
             raise client_err.SlackApiError(message=msg, response=resp)
         return url, resp.data
 

--- a/slack/web/slack_response.py
+++ b/slack/web/slack_response.py
@@ -79,7 +79,7 @@ class SlackResponse(object):
         return f"{self.data}"
 
     def __getitem__(self, key):
-        """Retreives any key from the data store.
+        """Retrieves any key from the data store.
 
         Note:
             This is implemented so users can reference the
@@ -106,7 +106,7 @@ class SlackResponse(object):
         return self
 
     def __next__(self):
-        """Retreives the next portion of results, if 'next_cursor' is present.
+        """Retrieves the next portion of results, if 'next_cursor' is present.
 
         Note:
             Some responses return collections of information
@@ -147,7 +147,7 @@ class SlackResponse(object):
             raise StopIteration
 
     def get(self, key, default=None):
-        """Retreives any key from the response data.
+        """Retrieves any key from the response data.
 
         Note:
             This is implemented so users can reference the

--- a/tests/rtm/test_rtm_client.py
+++ b/tests/rtm/test_rtm_client.py
@@ -94,5 +94,5 @@ class TestRTMClient(unittest.TestCase):
         with self.assertRaises(e.SlackApiError) as context:
             slack.RTMClient(token="xoxp-1234", auto_reconnect=False).start()
 
-        expected_error = "Unable to retreive RTM URL from Slack"
+        expected_error = "Unable to retrieve RTM URL from Slack"
         self.assertIn(expected_error, str(context.exception))


### PR DESCRIPTION
###  Summary

While debugging an error in one of my own projects, I noticed in a stacktrace that `RTMClient._retreive_websocket_info` has a typo, where `retrieve` is misspelled as `retreive`. I went ahead and corrected that typo wherever it occurred in the repo.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).