### PR TITLE
Allow running RTM over a thread

### DIFF
--- a/slack/rtm/client.py
+++ b/slack/rtm/client.py
@@ -10,6 +10,7 @@ import inspect
 import signal
 from typing import Optional, Callable, DefaultDict
 from ssl import SSLContext
+from threading import current_thread, main_thread
 
 # ThirdParty Imports
 import asyncio
@@ -185,7 +186,7 @@ class RTMClient(object):
             SlackApiError: Unable to retreive RTM URL from Slack.
         """
         # TODO: Add Windows support for graceful shutdowns.
-        if os.name != "nt":
+        if os.name != "nt" and current_thread() == main_thread():
             signals = (signal.SIGHUP, signal.SIGTERM, signal.SIGINT)
             for s in signals:
                 self._event_loop.add_signal_handler(s, self.stop)


### PR DESCRIPTION
###  Summary

When trying to start a RTM connection over a thread a RuntimeError appears:
RuntimeError: set_wakeup_fd only works in main thread
This change allows it.
Issue: #605 

### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).