### PR TITLE
WIP: Feature flag to skip adding signal handlers

### DIFF
--- a/slack/rtm/client.py
+++ b/slack/rtm/client.py
@@ -137,6 +137,7 @@ class RTMClient(object):
         self._last_message_id = 0
         self._connection_attempts = 0
         self._stopped = False
+        self._disable_signals = disable_signals
         self._web_client = WebClient(
             token=self.token,
             base_url=self.base_url,
@@ -198,7 +199,7 @@ class RTMClient(object):
             SlackApiError: Unable to retrieve RTM URL from Slack.
         """
         # TODO: Add Windows support for graceful shutdowns.
-        if os.name != "nt" and current_thread() == main_thread():
+        if os.name != "nt" and current_thread() == main_thread() and not self._disable_signals:
             signals = (signal.SIGHUP, signal.SIGTERM, signal.SIGINT)
             for s in signals:
                 self._event_loop.add_signal_handler(s, self.stop)

--- a/slack/rtm/client.py
+++ b/slack/rtm/client.py
@@ -54,6 +54,9 @@ class RTMClient(object):
         loop (AbstractEventLoop): An event loop provided by asyncio.
             If None is specified we attempt to use the current loop
             with `get_event_loop`. Default is None.
+        disable_signals (bool): If True, slack client won't add signal handlers
+            to catch shutdown signals.  Useful if you want to create a custom shutdown
+            function.  Default is False.
 
     Methods:
         ping: Sends a ping message over the websocket to Slack.
@@ -114,6 +117,7 @@ class RTMClient(object):
         ping_interval: Optional[int] = 30,
         loop: Optional[asyncio.AbstractEventLoop] = None,
         headers: Optional[dict] = {},
+        disable_signals: Optional[bool] = False,
     ):
         self.token = token.strip()
         self.run_async = run_async

--- a/tests/rtm/test_rtm_client.py
+++ b/tests/rtm/test_rtm_client.py
@@ -24,7 +24,7 @@ class TestRTMClient(unittest.TestCase):
         @slack.RTMClient.run_on(event="message")
         def fn_used_elsewhere(**_unused_payload):
             pass
-
+        
         self.assertIsNotNone(fn_used_elsewhere)
         self.assertEqual(fn_used_elsewhere.__name__, "fn_used_elsewhere")
 

--- a/tests/rtm/test_rtm_client.py
+++ b/tests/rtm/test_rtm_client.py
@@ -24,7 +24,7 @@ class TestRTMClient(unittest.TestCase):
         @slack.RTMClient.run_on(event="message")
         def fn_used_elsewhere(**_unused_payload):
             pass
-        
+
         self.assertIsNotNone(fn_used_elsewhere)
         self.assertEqual(fn_used_elsewhere.__name__, "fn_used_elsewhere")
 

--- a/tests/rtm/test_rtm_client_functional.py
+++ b/tests/rtm/test_rtm_client_functional.py
@@ -97,9 +97,8 @@ class TestRTMClientFunctional(unittest.TestCase):
 
             if rtm_client._connection_attempts == 1:
                 raise e.SlackApiError("Test Error", {"headers": {"Retry-After": 0.001}})
-            else:
-                self.assertEqual(rtm_client._connection_attempts, 2)
-                rtm_client.stop()
+            self.assertEqual(rtm_client._connection_attempts, 2)
+            rtm_client.stop()
 
         self.client.auto_reconnect = True
         self.client.start()

--- a/tests/rtm/test_rtm_client_functional.py
+++ b/tests/rtm/test_rtm_client_functional.py
@@ -54,30 +54,25 @@ class TestRTMClientFunctional(unittest.TestCase):
         app.router.add_get("/", self.websocket_handler)
         app.on_shutdown.append(self.on_shutdown)
         runner = web.AppRunner(app)
-        await
-        runner.setup()
+        await runner.setup()
         self.site = web.TCPSite(runner, "localhost", 8765)
-        await
-        self.site.start()
+        await self.site.start()
 
     async def websocket_handler(self, request):
         ws = web.WebSocketResponse()
-        await
-        ws.prepare(request)
+        await ws.prepare(request)
 
         request.app["websockets"].append(ws)
         try:
             async for msg in ws:
-                await
-                ws.send_json({"type": "message", "message_sent": msg.json()})
+                await ws.send_json({"type": "message", "message_sent": msg.json()})
         finally:
             request.app["websockets"].remove(ws)
         return ws
 
     async def on_shutdown(self, app):
         for ws in set(app["websockets"]):
-            await
-            ws.close(code=WSCloseCode.GOING_AWAY, message="Server shutdown")
+            await ws.close(code=WSCloseCode.GOING_AWAY, message="Server shutdown")
 
     # -------------------------------------------
 
@@ -181,8 +176,7 @@ class TestRTMClientFunctional(unittest.TestCase):
         @slack.RTMClient.run_on(event="open")
         async def ping_message(**payload):
             rtm_client = payload["rtm_client"]
-            await
-            rtm_client.ping()
+            await rtm_client.ping()
 
         @slack.RTMClient.run_on(event="message")
         def check_message(**payload):
@@ -197,8 +191,7 @@ class TestRTMClientFunctional(unittest.TestCase):
         @slack.RTMClient.run_on(event="open")
         async def typing_message(**payload):
             rtm_client = payload["rtm_client"]
-            await
-            rtm_client.typing(channel="C01234567")
+            await rtm_client.typing(channel="C01234567")
 
         @slack.RTMClient.run_on(event="message")
         def check_message(**payload):

--- a/tests/rtm/test_rtm_client_functional.py
+++ b/tests/rtm/test_rtm_client_functional.py
@@ -292,7 +292,7 @@ class TestRTMClientFunctional(unittest.TestCase):
         self.client._disable_signals = True
         self.client._event_loop = Mock()
         FakeTask = Mock()
-        FakeTask._source_traceback = None
+        FakeTask._source_traceback = []
         self.client._event_loop.create_task.return_value = FakeTask()
         self.client.start()
         self.client._event_loop.add_signal_handler.assert_not_called()

--- a/tests/rtm/test_rtm_client_functional.py
+++ b/tests/rtm/test_rtm_client_functional.py
@@ -291,8 +291,8 @@ class TestRTMClientFunctional(unittest.TestCase):
     ):
         self.client._disable_signals = True
         self.client._event_loop = Mock()
-        FakeTask = Mock()
-        FakeTask._source_traceback = []
+        class FakeTask:
+            _source_traceback = []
         self.client._event_loop.create_task.return_value = FakeTask()
         self.client.start()
         self.client._event_loop.add_signal_handler.assert_not_called()

--- a/tests/rtm/test_rtm_client_functional.py
+++ b/tests/rtm/test_rtm_client_functional.py
@@ -3,6 +3,7 @@ import collections
 import unittest
 
 from aiohttp import web, WSCloseCode
+from unittest.mock import Mock
 
 import slack
 import slack.errors as e
@@ -289,11 +290,9 @@ class TestRTMClientFunctional(unittest.TestCase):
             self, *args
     ):
         self.client._disable_signals = True
-        self.client._event_loop = unittest.mock.Mock()
-
-        FakeTask = unittest.mock.Mock()
+        self.client._event_loop = Mock()
+        FakeTask = Mock()
         FakeTask._source_traceback = None
-
         self.client._event_loop.create_task.return_value = FakeTask()
         self.client.start()
         self.client._event_loop.add_signal_handler.assert_not_called()

--- a/tests/rtm/test_rtm_client_functional.py
+++ b/tests/rtm/test_rtm_client_functional.py
@@ -284,3 +284,16 @@ class TestRTMClientFunctional(unittest.TestCase):
         client.start()  # intentionally no await here
         await asyncio.sleep(3)
         self.assertFalse(self.called)
+
+    def test_start_disable_signals(
+            self, *args
+    ):
+        self.client._disable_signals = True
+        self.client._event_loop = unittest.mock.Mock()
+
+        FakeTask = unittest.mock.Mock()
+        FakeTask._source_traceback = None
+
+        self.client._event_loop.create_task.return_value = FakeTask()
+        self.client.start()
+        self.client._event_loop.add_signal_handler.assert_not_called()

--- a/tests/rtm/test_rtm_client_functional.py
+++ b/tests/rtm/test_rtm_client_functional.py
@@ -54,25 +54,30 @@ class TestRTMClientFunctional(unittest.TestCase):
         app.router.add_get("/", self.websocket_handler)
         app.on_shutdown.append(self.on_shutdown)
         runner = web.AppRunner(app)
-        await runner.setup()
+        await
+        runner.setup()
         self.site = web.TCPSite(runner, "localhost", 8765)
-        await self.site.start()
+        await
+        self.site.start()
 
     async def websocket_handler(self, request):
         ws = web.WebSocketResponse()
-        await ws.prepare(request)
+        await
+        ws.prepare(request)
 
         request.app["websockets"].append(ws)
         try:
             async for msg in ws:
-                await ws.send_json({"type": "message", "message_sent": msg.json()})
+                await
+                ws.send_json({"type": "message", "message_sent": msg.json()})
         finally:
             request.app["websockets"].remove(ws)
         return ws
 
     async def on_shutdown(self, app):
         for ws in set(app["websockets"]):
-            await ws.close(code=WSCloseCode.GOING_AWAY, message="Server shutdown")
+            await
+            ws.close(code=WSCloseCode.GOING_AWAY, message="Server shutdown")
 
     # -------------------------------------------
 
@@ -176,7 +181,8 @@ class TestRTMClientFunctional(unittest.TestCase):
         @slack.RTMClient.run_on(event="open")
         async def ping_message(**payload):
             rtm_client = payload["rtm_client"]
-            await rtm_client.ping()
+            await
+            rtm_client.ping()
 
         @slack.RTMClient.run_on(event="message")
         def check_message(**payload):
@@ -191,7 +197,8 @@ class TestRTMClientFunctional(unittest.TestCase):
         @slack.RTMClient.run_on(event="open")
         async def typing_message(**payload):
             rtm_client = payload["rtm_client"]
-            await rtm_client.typing(channel="C01234567")
+            await
+            rtm_client.typing(channel="C01234567")
 
         @slack.RTMClient.run_on(event="message")
         def check_message(**payload):


### PR DESCRIPTION
###  Summary

It's possible to override these signal handlers after the client is started, however, I have encountered some race conditions that have been hard to debug.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).