### PR TITLE
Add py.typed file to package distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include README.md LICENSE
+include README.md LICENSE slack/py.typed


### PR DESCRIPTION
###  Summary

A `py.typed` file was requested in #524 and added in #541. Unfortunately, as far as I can tell, it's not included with the package distribution and thus doesn't help end users yet. [PEP 0561](https://www.python.org/dev/peps/pep-0561/#packaging-type-information) mentions adding the file in `setup.py` with the `package_data` key, however, you're using `include_package_data` already, so I believe modifying `MANIFEST.in` is the correct change to make.

Please feel free to test things out, I'm not very familiar with typical Python packaging practices. I believe as long as the `py.typed` file gets included in the published package, we should be good to go, and end users should be able to get type-checking automatically for this package.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).