### PR TITLE
WIP: Fix #625 #626 event RuntimeError in pagination, and unicode error when logging

### DIFF
--- a/slack/web/slack_response.py
+++ b/slack/web/slack_response.py
@@ -74,6 +74,15 @@ class SlackResponse(object):
         self._client = client
         self._logger = logging.getLogger(__name__)
 
+    def _get_event_loop(self):
+        """Retrieves the event loop or creates a new one."""
+        try:
+            return asyncio.get_event_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            return loop
+
     def __str__(self):
         """Return the Response data if object is converted to a string."""
         return f"{self.data}"
@@ -132,7 +141,7 @@ class SlackResponse(object):
                 {"cursor": self.data["response_metadata"]["next_cursor"]}
             )
 
-            response = asyncio.get_event_loop().run_until_complete(
+            response = self._get_event_loop().run_until_complete(
                 self._client._request(
                     http_verb=self.http_verb,
                     api_url=self.api_url,
@@ -170,7 +179,7 @@ class SlackResponse(object):
             SlackApiError: The request to the Slack API failed.
         """
         if self.status_code == 200 and self.data.get("ok", False):
-            self._logger.debug("Received the following response: %s", self.data)
+            self._logger.debug(u"Received the following response: %s", self.data)
             return self
         msg = "The request to the Slack API failed."
         raise e.SlackApiError(message=msg, response=self)

--- a/slack/web/slack_response.py
+++ b/slack/web/slack_response.py
@@ -75,7 +75,7 @@ class SlackResponse(object):
         self._logger = logging.getLogger(__name__)
 
     @staticmethod
-    def _get_event_loop(cls):
+    def _get_event_loop():
         """Retrieves the event loop or creates a new one."""
         try:
             return asyncio.get_event_loop()

--- a/slack/web/slack_response.py
+++ b/slack/web/slack_response.py
@@ -74,7 +74,8 @@ class SlackResponse(object):
         self._client = client
         self._logger = logging.getLogger(__name__)
 
-    def _get_event_loop(self):
+    @staticmethod
+    def _get_event_loop(cls):
         """Retrieves the event loop or creates a new one."""
         try:
             return asyncio.get_event_loop()


### PR DESCRIPTION
###  Summary

This change fixes #626 and #625, by fixing asyncio event loop issues when pagination is used, and using unicode rather than strings for logging a debug log that will contain unicode.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).