### PR TITLE
Fix #635 DatePickerElement initial_date validation is incorrect

### DIFF
--- a/slack/web/classes/elements.py
+++ b/slack/web/classes/elements.py
@@ -554,5 +554,5 @@ class DatePickerElement(AbstractSelector):
     @JsonValidator("initial_date attribute must be in format 'YYYY-MM-DD'")
     def initial_date_valid(self):
         return self.initial_date is None or re.match(
-            r"\d{4}-[01][12]-[0123]\d", self.initial_date
+            r"\d{4}-(0[1-9]|1[0-2])-([0-2][1-9]|3[01])", self.initial_date
         )

--- a/tests/web/classes/test_elements.py
+++ b/tests/web/classes/test_elements.py
@@ -5,6 +5,7 @@ from slack.web.classes.elements import (
     ButtonElement,
     ChannelSelectElement,
     ConversationSelectElement,
+    DatePickerElement,
     ExternalDataSelectElement,
     ImageElement,
     LinkButtonElement,
@@ -232,5 +233,29 @@ class DynamicDropdownTests(unittest.TestCase):
                         "action_id": "dropdown",
                         f"initial_{dropdown_type.initial_object_type}": "def",
                         "type": f"{dropdown_type.initial_object_type}s_select",
+                    },
+                )
+
+
+class DatePickerElementTests(unittest.TestCase):
+    def test_json(self):
+        for month in range(1 - 12):
+            for day in range(1 - 31):
+                date = f"2020-{month:02}-{day:02}"
+                self.assertDictEqual(
+                    DatePickerElement(
+                        action_id="datepicker-action",
+                        placeholder="Select a date",
+                        initial_date=date,
+                    ).to_dict(),
+                    {
+                        "action_id": "datepicker-action",
+                        "initial_date": date,
+                        "placeholder": {
+                            "emoji": True,
+                            "text": "Select a date",
+                            "type": "plain_text",
+                        },
+                        "type": "datepicker",
                     },
                 )


### PR DESCRIPTION
###  Summary

This pull request fixes a bug reported at #635.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).