### PR TITLE
im_open requires positional arg, user key gives user_id

### DIFF
--- a/tutorial/PythOnBoardingBot/app.py
+++ b/tutorial/PythOnBoardingBot/app.py
@@ -51,7 +51,7 @@ def onboarding_message(payload):
     event = payload.get("event", {})
 
     # Get the id of the Slack user associated with the incoming event
-    user_id = event.get("user", {})
+    user_id = event.get("user", {}).get("id")
 
     # Open a DM with the new user.
     response = slack_web_client.im_open(user=user_id)

--- a/tutorial/PythOnBoardingBot/app.py
+++ b/tutorial/PythOnBoardingBot/app.py
@@ -51,10 +51,10 @@ def onboarding_message(payload):
     event = payload.get("event", {})
 
     # Get the id of the Slack user associated with the incoming event
-    user_id = event.get("user", {}).get("id")
+    user_id = event.get("user", {})
 
     # Open a DM with the new user.
-    response = slack_web_client.im_open(user_id)
+    response = slack_web_client.im_open(user=user_id)
     channel = response["channel"]["id"]
 
     # Post the onboarding message.


### PR DESCRIPTION
###  Summary

This is to fix some bug in the tutorial code:
1. WebClient#im_open expects positional user argument

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).