### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ client = slack.WebClient(
     run_async=True
     )
 
-async def send_async_message(channel='#random', text='')
+async def send_async_message(channel='#random', text=''):
     response = await client.chat_postMessage(
             channel=channel,
             text=text


### PR DESCRIPTION
Added missing column `:` to Readme

###  Summary
A single character change to the example in the ReadME file. 
The async example when running in Jupyter had a typo in the function definition. 

I understand this is a small detail, but that example solved my problem, so I think it deserves to be corrected as it will cause the same error across multiple people using the same example.

### Requirements (place an `x` in each `[ ]`)

* [ x ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [ x ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).