### PR TITLE
Fix #594 preview_image for files.remote.add API method is not properly supported

### DIFF
--- a/integration_tests/web/test_issue_594.py
+++ b/integration_tests/web/test_issue_594.py
@@ -4,13 +4,10 @@ import os
 import unittest
 from uuid import uuid4
 
-import pytest
-
 from integration_tests.env_variable_names import \
     SLACK_SDK_TEST_BOT_TOKEN, \
     SLACK_SDK_TEST_WEB_TEST_CHANNEL_ID, \
     SLACK_SDK_TEST_WEB_TEST_USER_ID
-from integration_tests.helpers import is_not_specified
 from slack import WebClient
 
 
@@ -31,7 +28,6 @@ class TestWebClient(unittest.TestCase):
     def tearDown(self):
         pass
 
-    @pytest.mark.skipif(condition=is_not_specified(), reason="still unfixed")
     def test_issue_594(self):
         client, logger = self.sync_client, self.logger
         external_url = "https://www.example.com/good-old-slack-logo"

--- a/slack/web/client.py
+++ b/slack/web/client.py
@@ -1001,7 +1001,18 @@ class WebClient(BaseClient):
         kwargs.update(
             {"external_id": external_id, "external_url": external_url, "title": title}
         )
-        return self.api_call("files.remote.add", http_verb="GET", params=kwargs)
+        files = None
+        # preview_image (file): Preview of the document via multipart/form-data.
+        if "preview_image" in kwargs:
+            files = {"preview_image": kwargs.pop("preview_image")}
+
+        return self.api_call(
+            # Intentionally using "POST" method over "GET" here
+            "files.remote.add",
+            http_verb="POST",
+            data=kwargs,
+            files=files,
+        )
 
     def files_remote_update(self, **kwargs) -> Union[Future, SlackResponse]:
         """Updates an existing remote file."""


### PR DESCRIPTION
###  Summary

This pull request fixes #594 by adding support or `preview_image` parameter for `files.remote.add` API method calls.

In another PR #653 , I'm working on integration tests to enable us to verify if changes work with real APIs as expected. [This commit](https://github.com/slackapi/python-slackclient/pull/653/commits/399f89b523296cd966343d8022a0abaf68ae7a54) in that PR adds a test case for this issue and I've already verified this PR's patch fixes the issue.

After merging #653 ,  I will merge this PR as well.

Reference: https://api.slack.com/methods/files.remote.add

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).