### PR TITLE
Fix #660 channel_ids in admin.users.invite calls doesn't work

### DIFF
--- a/slack/web/client.py
+++ b/slack/web/client.py
@@ -79,7 +79,7 @@ class WebClient(BaseClient):
             app_id (str): The id of the app to approve. e.g. 'A12345'
             request_id (str): The id of the request to approve. e.g. 'Ar12345'
         Raises:
-            SlackRequestError: If niether or both the `app_id` and `request_id` args are specified.
+            SlackRequestError: If neither or both the `app_id` and `request_id` args are specified.
         """
         if app_id:
             kwargs.update({"app_id": app_id})
@@ -323,7 +323,7 @@ class WebClient(BaseClient):
             channel_ids (list): A list of channel_ids for this user to join.
                 At least one channel is required. e.g. ['C1A2B3C4D', 'C26Z25Y24']
         """
-        kwargs.update({"team_id": team_id, "email": email, "channel_ids": channel_ids})
+        kwargs.update({"team_id": team_id, "email": email, "channel_ids": ",".join(channel_ids)})
         return self.api_call("admin.users.invite", json=kwargs)
 
     def admin_users_list(


### PR DESCRIPTION
###  Summary

This pull request fixes #660 by correcting the way to handle the `channel_ids` parameter. It needs to be a comma-separated list of channel IDs in a single string value.

https://api.slack.com/methods/admin.users.invite#arg_channel_ids

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).