### PR TITLE
Add a test demonstrating how to use response.data ref #559

### DIFF
--- a/tests/web/test_slack_response.py
+++ b/tests/web/test_slack_response.py
@@ -1,0 +1,33 @@
+import unittest
+
+from slack import WebClient
+from slack.web.slack_response import SlackResponse
+
+
+class TestSlackResponse(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    # https://github.com/slackapi/python-slackclient/issues/559
+    def test_issue_559(self):
+        response = SlackResponse(
+            client=WebClient(token="xoxb-dummy"),
+            http_verb="POST",
+            api_url="http://localhost:3000/api.test",
+            req_args={},
+            data={
+                "ok": True,
+                "args": {
+                    "hello": "world"
+                }
+            },
+            headers={},
+            status_code=200,
+        )
+
+        self.assertTrue("ok" in response.data)
+        self.assertTrue("args" in response.data)
+        self.assertFalse("error" in response.data)


### PR DESCRIPTION
###  Summary

This pull request just adds a sample demonstrating how to use `response.data`. 

I was going to implement the `__contains__` dunder method at the top level of `SlackResponse` (suggestion at #559) but I came to think it may result in unexpected behavior for other use cases and `key in response.data` is also simple enough.

Let me close #559 after merging this sample.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).