### PR TITLE
Correct type hints for extract_json method

### DIFF
--- a/slack/web/classes/__init__.py
+++ b/slack/web/classes/__init__.py
@@ -1,6 +1,6 @@
 from abc import ABCMeta, abstractmethod
 from functools import wraps
-from typing import Callable, Iterable, List, Set, Union
+from typing import Callable, Iterable, List, Set, Union, Dict, Any
 
 from ...errors import SlackObjectFormationError
 
@@ -91,8 +91,8 @@ class EnumValidator(JsonValidator):
 
 
 def extract_json(
-    item_or_items: Union[JsonObject, List[JsonObject], str], *format_args
-) -> Union[dict, List[dict], str]:
+    item_or_items: Union[JsonObject, List[JsonObject]], *format_args
+) -> Union[Dict[Any, Any], List[Dict[Any, Any]]]:
     """
     Given a sequence (or single item), attempt to call the to_dict() method on each
     item and return a plain list. If item is not the expected type, return it

--- a/slack/web/classes/__init__.py
+++ b/slack/web/classes/__init__.py
@@ -14,9 +14,7 @@ class JsonObject(BaseObject, metaclass=ABCMeta):
     @property
     @abstractmethod
     def attributes(self) -> Set[str]:
-        """
-        Provide a set of attributes of this object that will make up its JSON structure
-        """
+        """Provide a set of attributes of this object that will make up its JSON structure"""
         return set()
 
     def validate_json(self) -> None:
@@ -25,7 +23,7 @@ class JsonObject(BaseObject, metaclass=ABCMeta):
           SlackObjectFormationError if the object was not valid
         """
         for attribute in (func for func in dir(self) if not func.startswith("__")):
-            method = getattr(self, attribute)
+            method = getattr(self, attribute, None)
             if callable(method) and hasattr(method, "validator"):
                 method()
 
@@ -57,8 +55,7 @@ class JsonObject(BaseObject, metaclass=ABCMeta):
         json = self.to_dict()
         if json:
             return f"<slack.{self.__class__.__name__}: {json}>"
-        else:
-            return self.__str__()
+        return self.__str__()
 
 
 class JsonValidator:

--- a/tests/web/classes/test_init.py
+++ b/tests/web/classes/test_init.py
@@ -1,0 +1,24 @@
+import unittest
+
+from slack.web.classes import extract_json
+from slack.web.classes.objects import PlainTextObject, MarkdownTextObject
+
+
+class TestInit(unittest.TestCase):
+    def test_from_list_of_json_objects(self):
+        input = [
+            PlainTextObject(text="foo"),
+            MarkdownTextObject(text="bar"),
+        ]
+        output = extract_json(input)
+        expected = {"result": [
+            {"type": "plain_text", "text": "foo", "emoji": True},
+            {"type": "mrkdwn", "text": "bar", "verbatim": False},
+        ]}
+        self.assertDictEqual(expected, {"result": output})
+
+    def test_from_single_json_object(self):
+        input = PlainTextObject(text="foo")
+        output = extract_json(input)
+        expected = {"result": {"type": "plain_text", "text": "foo", "emoji": True}}
+        self.assertDictEqual(expected, {"result": output})

--- a/tests/web/classes/test_init.py
+++ b/tests/web/classes/test_init.py
@@ -6,11 +6,11 @@ from slack.web.classes.objects import PlainTextObject, MarkdownTextObject
 
 class TestInit(unittest.TestCase):
     def test_from_list_of_json_objects(self):
-        input = [
+        json_objects = [
             PlainTextObject(text="foo"),
             MarkdownTextObject(text="bar"),
         ]
-        output = extract_json(input)
+        output = extract_json(json_objects)
         expected = {"result": [
             {"type": "plain_text", "text": "foo", "emoji": True},
             {"type": "mrkdwn", "text": "bar", "verbatim": False},
@@ -18,7 +18,7 @@ class TestInit(unittest.TestCase):
         self.assertDictEqual(expected, {"result": output})
 
     def test_from_single_json_object(self):
-        input = PlainTextObject(text="foo")
-        output = extract_json(input)
+        single_json_object = PlainTextObject(text="foo")
+        output = extract_json(single_json_object)
         expected = {"result": {"type": "plain_text", "text": "foo", "emoji": True}}
         self.assertDictEqual(expected, {"result": output})


### PR DESCRIPTION
###  Summary

This pull request corrects the type hints given to `slack.web.classes.extract_json`.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).