### PR TITLE
Fix #558 #619 by revising RTMClient to accept simultaneous incoming messages

### DIFF
--- a/integration_tests/rtm/test_issue_558.py
+++ b/integration_tests/rtm/test_issue_558.py
@@ -27,7 +27,7 @@ class TestRTMClient(unittest.TestCase):
         # Reset the decorators by @RTMClient.run_on
         RTMClient._callbacks = collections.defaultdict(list)
 
-    @pytest.mark.skipif(condition=is_not_specified(), reason="still unfixed")
+    @pytest.mark.skipif(condition=is_not_specified(), reason="To avoid rate limited errors")
     @async_test
     async def test_issue_558(self):
         channel_id = os.environ[SLACK_SDK_TEST_RTM_TEST_CHANNEL_ID]
@@ -38,7 +38,7 @@ class TestRTMClient(unittest.TestCase):
         async def process_messages(**payload):
             self.logger.debug(payload)
             self.message_count += 1
-            await asyncio.sleep(10)  # this blocks all handlers
+            await asyncio.sleep(10)  # this used to block all other handlers
 
         async def process_reactions(**payload):
             self.logger.debug(payload)
@@ -65,7 +65,7 @@ class TestRTMClient(unittest.TestCase):
 
             message = await web_client.chat_postMessage(channel=channel_id, text=text)
             self.assertFalse("error" in message)
-            # start blocking here
+            # used to start blocking here
 
             # This reaction_add event won't be handled due to a bug
             second_reaction = await web_client.reactions_add(channel=channel_id, timestamp=ts, name="tada")
@@ -73,7 +73,7 @@ class TestRTMClient(unittest.TestCase):
             await asyncio.sleep(2)
 
             self.assertEqual(self.message_count, 1)
-            self.assertEqual(self.reaction_count, 2)  # fails
+            self.assertEqual(self.reaction_count, 2)  # used to fail
         finally:
             if not rtm._stopped:
                 rtm.stop()


### PR DESCRIPTION
###  Summary

This pull request fixes #558 #619.

The cause of the issue addressed by this pull request is that the current implementation of `RTMClient` handles incoming WebSocket messages one by one (=sequentially). As a result, the following code blocks other handlers until the sleep time (10 seconds) passes.

```python
@RTMClient.run_on(event="message")
async def process_messages(**payload):
    self.logger.debug(payload)
    await asyncio.sleep(10)  # this used to block all other handlers
```

This pull request changes the internals of `RTMClient` a bit to accept simultaneous text messages. Error events and connection close events should not be executed asynchronously.

@stevengill @aoberoi @shaydewael 
As #665 and this pull request have a conflict, I need to merge them into one. But I think having reviews separately should be easier for these cases. After waiting for reviews by others for a few business days, I'll come up with a unified pull request and close this and #665.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).