### PR TITLE
Fix #670 by removing all None values from dict

### DIFF
--- a/integration_tests/web/test_issue_670.py
+++ b/integration_tests/web/test_issue_670.py
@@ -1,0 +1,50 @@
+import asyncio
+import io
+import logging
+import os
+import unittest
+
+from integration_tests.env_variable_names import SLACK_SDK_TEST_BOT_TOKEN
+from integration_tests.helpers import async_test
+from slack import WebClient
+
+
+class TestWebClient(unittest.TestCase):
+    """Runs integration tests with real Slack API
+
+    https://github.com/slackapi/python-slackclient/issues/670
+    """
+
+    def setUp(self):
+        self.logger = logging.getLogger(__name__)
+        self.bot_token = os.environ[SLACK_SDK_TEST_BOT_TOKEN]
+        self.sync_client: WebClient = WebClient(token=self.bot_token, run_async=False, loop=asyncio.new_event_loop())
+        self.async_client: WebClient = WebClient(token=self.bot_token, run_async=True)
+
+    def tearDown(self):
+        pass
+
+    def test_issue_670(self):
+        client = self.sync_client
+        buff = io.BytesIO(b'here is my data but not sure what is wrong.......')
+        buff.seek(0)
+        upload = client.files_upload(
+            file=buff,
+            filename="output.text",
+            filetype="text",
+            title=None,
+        )
+        self.assertIsNotNone(upload)
+
+    @async_test
+    async def test_issue_670_async(self):
+        client = self.async_client
+        buff = io.BytesIO(b'here is my data but not sure what is wrong.......')
+        buff.seek(0)
+        upload = await client.files_upload(
+            file=buff,
+            filename="output.text",
+            filetype="text",
+            title=None,
+        )
+        self.assertIsNotNone(upload)

--- a/slack/web/base_client.py
+++ b/slack/web/base_client.py
@@ -149,6 +149,13 @@ class BaseClient:
         if auth:
             auth = BasicAuth(auth["client_id"], auth["client_secret"])
 
+        if data:
+            data = {k: v for k, v in data.items() if v is not None}
+        if files:
+            files = {k: v for k, v in files.items() if v is not None}
+        if params:
+            params = {k: v for k, v in params.items() if v is not None}
+
         req_args = {
             "headers": self._get_headers(has_json, has_files, headers),
             "data": data,


### PR DESCRIPTION
###  Summary

This pull request fixes #670 by scanning None values from data, files, and params. There is no reason to keep them as they'll just result in TypeError.

After applying this change, the new sync mode WebClient in #662 also needs to be updated in the same manner.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).