### PR TITLE
Fix #560 Allow bool kwargs

### DIFF
--- a/integration_tests/web/test_issue_560.py
+++ b/integration_tests/web/test_issue_560.py
@@ -3,10 +3,8 @@ import logging
 import os
 import unittest
 
-import pytest
-
 from integration_tests.env_variable_names import SLACK_SDK_TEST_BOT_TOKEN
-from integration_tests.helpers import async_test, is_not_specified
+from integration_tests.helpers import async_test
 from slack import WebClient
 
 
@@ -33,35 +31,22 @@ class TestWebClient(unittest.TestCase):
         response = client.conversations_list(exclude_archived="true")
         self.assertIsNotNone(response)
 
-    @pytest.mark.skipif(condition=is_not_specified(), reason="still unfixed")
+    @async_test
+    async def test_issue_560_success_async(self):
+        client = self.async_client
+        response = await client.conversations_list(exclude_archived=1)
+        self.assertIsNotNone(response)
+
+        response = client.conversations_list(exclude_archived="true")
+        self.assertIsNotNone(response)
+
     def test_issue_560_failure(self):
         client = self.sync_client
         response = client.conversations_list(exclude_archived=True)
         self.assertIsNotNone(response)
 
-    @pytest.mark.skipif(condition=is_not_specified(), reason="still unfixed")
     @async_test
     async def test_issue_560_failure_async(self):
         client = self.async_client
         response = await client.conversations_list(exclude_archived=True)
         self.assertIsNotNone(response)
-
-    # _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
-    #
-    # v = True
-    #
-    #     @staticmethod
-    #     def _query_var(v):
-    #         if isinstance(v, str):
-    #             return v
-    #         if type(v) is int:  # no subclasses like bool
-    #             return str(v)
-    # >       raise TypeError(
-    #             "Invalid variable type: value "
-    #             "should be str or int, got {!r} "
-    #             "of type {}".format(v, type(v))
-    #         )
-    # E       TypeError: Invalid variable type: value should be str or int, got True of type <class 'bool'>
-    #
-    # path-to-python/site-packages/yarl/__init__.py:824: TypeError
-    # -------------------------------------------------------------------------------------------------- Captured log call --------------------------------------------------------------------------------------------------

--- a/slack/web/__init__.py
+++ b/slack/web/__init__.py
@@ -1,6 +1,35 @@
 import os
 import warnings
 
+from typing import Dict
+
+
+# ---------------------------------------
+
+
+def _to_0_or_1_if_bool(v: any) -> str:
+    if isinstance(v, bool):
+        return "1" if v else "0"
+    else:
+        return v
+
+
+def convert_bool_to_0_or_1(params: Dict[str, any]) -> Dict[str, any]:
+    """Converts all bool values in dict to "0" or "1".
+    Slack APIs safely accept "0"/"1" as boolean values.
+    Using True/False (bool in Python) doesn't work with aiohttp.
+    This method converts only the bool values in top-level of a given dict.
+    :param params: params as a dict
+    :return: return modified dict
+    """
+    if params:
+        return {k: _to_0_or_1_if_bool(v) for k, v in params.items()}
+    else:
+        return None
+
+
+# ---------------------------------------
+
 # https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 deprecated_method_prefixes_2020_01 = ["channels.", "groups.", "im.", "mpim."]
 

--- a/slack/web/__init__.py
+++ b/slack/web/__init__.py
@@ -10,8 +10,7 @@ from typing import Dict
 def _to_0_or_1_if_bool(v: any) -> str:
     if isinstance(v, bool):
         return "1" if v else "0"
-    else:
-        return v
+    return v
 
 
 def convert_bool_to_0_or_1(params: Dict[str, any]) -> Dict[str, any]:
@@ -24,8 +23,7 @@ def convert_bool_to_0_or_1(params: Dict[str, any]) -> Dict[str, any]:
     """
     if params:
         return {k: _to_0_or_1_if_bool(v) for k, v in params.items()}
-    else:
-        return None
+    return None
 
 
 # ---------------------------------------

--- a/slack/web/base_client.py
+++ b/slack/web/base_client.py
@@ -1,24 +1,26 @@
 """A Python module for interacting with Slack's Web API."""
 
-# Standard Imports
-from urllib.parse import urljoin
-import platform
-import sys
-import logging
 import asyncio
-from typing import Optional, Union
 import hashlib
 import hmac
+import logging
+import platform
+import sys
+from typing import Optional, Union
+
+# Standard Imports
+from urllib.parse import urljoin
 
 # ThirdParty Imports
 import aiohttp
 from aiohttp import FormData, BasicAuth
 
-# Internal Imports
-from slack.web import show_2020_01_deprecation
-from slack.web.slack_response import SlackResponse
-import slack.version as ver
 import slack.errors as err
+import slack.version as ver
+
+# Internal Imports
+from slack.web import show_2020_01_deprecation, convert_bool_to_0_or_1
+from slack.web.slack_response import SlackResponse
 
 
 class BaseClient:
@@ -221,6 +223,10 @@ class BaseClient:
                     req_args["data"].update({k: f})
                 else:
                     req_args["data"].update({k: v})
+
+        if "params" in req_args:
+            # True/False -> "1"/"0"
+            req_args["params"] = convert_bool_to_0_or_1(req_args["params"])
 
         res = await self._request(
             http_verb=http_verb, api_url=api_url, req_args=req_args

--- a/tests/web/test_web_client.py
+++ b/tests/web/test_web_client.py
@@ -6,6 +6,8 @@ import re
 
 
 # Internal Imports
+import pytest
+
 import slack
 from tests.helpers import async_test, fake_req_args, mock_request
 import slack.errors as err
@@ -186,3 +188,18 @@ class TestWebClient(unittest.TestCase):
             api_url="https://www.slack.com/api/users.setPhoto",
             req_args=fake_req_args(),
         )
+
+    @pytest.mark.skip(reason="hold off until #662")
+    def test_issue_560_bool_in_params_sync(self):
+        self.client.token = "xoxb-conversations_list"
+        self.client.conversations_list(exclude_archived=1)  # ok
+        self.client.conversations_list(exclude_archived="true")  # ok
+        self.client.conversations_list(exclude_archived=True)  # ok
+
+    @pytest.mark.skip(reason="hold off until #662")
+    @async_test
+    async def test_issue_560_bool_in_params_async(self):
+        self.async_client.token = "xoxb-conversations_list"
+        await self.async_client.conversations_list(exclude_archived=1)  # ok
+        await self.async_client.conversations_list(exclude_archived="true")  # ok
+        await self.async_client.conversations_list(exclude_archived=True)  # TypeError


### PR DESCRIPTION
###  Summary

To reduce the diff in #662, I've extracted the fix for #560 as this pull request. This pull request resolves #560 by having a conversion logic of bool values in `WebClient`. java-slack-sdk does the same here: https://github.com/slackapi/java-slack-sdk/blob/v1.0.7/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java#L1767-L1769

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).