### PR TITLE
Additional improvements for #686 and document updates

### DIFF
--- a/docs-src/basic_usage.rst
+++ b/docs-src/basic_usage.rst
@@ -178,19 +178,16 @@ Modals use the same blocks that compose messages with the addition of an `input`
 
 .. code-block:: python
 
+  # This module is available since v2.6.0rc1
+  from slack.signature import SignatureVerifier
+  signature_verifier = SignatureVerifier(os.environ["SLACK_SIGNING_SECRET"])
+
   from flask import Flask, request, make_response
   app = Flask(__name__)
-  signing_secret = os.environ["SLACK_SIGNING_SECRET"]
 
   @app.route("/slack/events", methods=["POST"])
   def slack_app():
-    # Refer to https://github.com/slackapi/python-slack-events-api
-    # (The Slack Team is going to provide a new package soon)
-    if not verify_request(
-      signing_secret=signing_secret,
-      request_body=request.get_data(),
-      timestamp=request.headers.get("X-Slack-Request-Timestamp"),
-      signature=request.headers.get("X-Slack-Signature")):
+    if not signature_verifier.is_valid_request(request.get_data(), request.headers):
       return make_response("invalid request", 403)
 
     if "command" in request.form \

--- a/tests/signature/test_signature_verifier.py
+++ b/tests/signature/test_signature_verifier.py
@@ -29,9 +29,13 @@ class TestSignatureVerifier(unittest.TestCase):
     }
 
     def test_generate_signature(self):
-        verifier = SignatureVerifier("8f742231b10e8888abcd99yyyzzz85a5")
-        timestamp = "1531420618"
-        signature = verifier.generate_signature(timestamp=timestamp, body=self.body)
+        verifier = SignatureVerifier(self.signing_secret)
+        signature = verifier.generate_signature(timestamp=self.timestamp, body=self.body)
+        self.assertEqual(self.valid_signature, signature)
+
+    def test_generate_signature_body_as_bytes(self):
+        verifier = SignatureVerifier(self.signing_secret)
+        signature = verifier.generate_signature(timestamp=self.timestamp, body=self.body.encode("utf-8"))
         self.assertEqual(self.valid_signature, signature)
 
     def test_is_valid_request(self):
@@ -41,6 +45,13 @@ class TestSignatureVerifier(unittest.TestCase):
         )
         self.assertTrue(verifier.is_valid_request(self.body, self.headers))
 
+    def test_is_valid_request_body_as_bytes(self):
+        verifier = SignatureVerifier(
+            signing_secret=self.signing_secret,
+            clock=MockClock()
+        )
+        self.assertTrue(verifier.is_valid_request(self.body.encode("utf-8"), self.headers))
+
     def test_is_valid_request_invalid_body(self):
         verifier = SignatureVerifier(
             signing_secret=self.signing_secret,
@@ -48,6 +59,14 @@ class TestSignatureVerifier(unittest.TestCase):
         )
         modified_body = self.body + "------"
         self.assertFalse(verifier.is_valid_request(modified_body, self.headers))
+
+    def test_is_valid_request_invalid_body_as_bytes(self):
+        verifier = SignatureVerifier(
+            signing_secret=self.signing_secret,
+            clock=MockClock(),
+        )
+        modified_body = self.body + "------"
+        self.assertFalse(verifier.is_valid_request(modified_body.encode("utf-8"), self.headers))
 
     def test_is_valid_request_expiration(self):
         verifier = SignatureVerifier(


### PR DESCRIPTION
###  Summary

This pull request applies a minor improvement to #686 by having consideration for the "body" parameter as a `bytes` value. Also, it updates to the related document.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).