### PR TITLE
Add more validation rules for view construction (thanks to feedback in #519)

### DIFF
--- a/integration_tests/samples/basic_usage/views_2.py
+++ b/integration_tests/samples/basic_usage/views_2.py
@@ -1,0 +1,88 @@
+# ------------------
+# Only for running this script here
+import json
+import logging
+import sys
+from os.path import dirname
+
+sys.path.insert(1, f"{dirname(__file__)}/../../..")
+logging.basicConfig(level=logging.DEBUG)
+
+# ---------------------
+# Slack WebClient
+# ---------------------
+
+import os
+
+from slack import WebClient
+from slack.errors import SlackApiError
+from slack.signature import SignatureVerifier
+from slack.web.classes.blocks import InputBlock
+from slack.web.classes.elements import PlainTextInputElement
+from slack.web.classes.objects import PlainTextObject
+from slack.web.classes.views import View
+
+client = WebClient(token=os.environ["SLACK_API_TOKEN"])
+signature_verifier = SignatureVerifier(os.environ["SLACK_SIGNING_SECRET"])
+
+# ---------------------
+# Flask App
+# ---------------------
+
+# pip3 install flask
+from flask import Flask, request, make_response
+
+app = Flask(__name__)
+
+
+@app.route("/slack/events", methods=["POST"])
+def slack_app():
+    if not signature_verifier.is_valid_request(request.get_data(), request.headers):
+        return make_response("invalid request", 403)
+
+    if "command" in request.form \
+        and request.form["command"] == "/open-modal":
+        trigger_id = request.form["trigger_id"]
+        try:
+            view = View(
+                type="modal",
+                callback_id="modal-id",
+                title=PlainTextObject(text="Awesome Modal"),
+                submit=PlainTextObject(text="Submit"),
+                close=PlainTextObject(text="Cancel"),
+                blocks=[
+                    InputBlock(
+                        block_id="b-id",
+                        label=PlainTextObject(text="Input label"),
+                        element=PlainTextInputElement(action_id="a-id")
+                    )
+                ]
+            )
+            response = client.views_open(
+                trigger_id=trigger_id,
+                view=view
+            )
+            return make_response("", 200)
+        except SlackApiError as e:
+            code = e.response["error"]
+            return make_response(f"Failed to open a modal due to {code}", 200)
+
+    elif "payload" in request.form:
+        payload = json.loads(request.form["payload"])
+        if payload["type"] == "view_submission" \
+            and payload["view"]["callback_id"] == "modal-id":
+            submitted_data = payload["view"]["state"]["values"]
+            print(submitted_data)  # {'b-id': {'a-id': {'type': 'plain_text_input', 'value': 'your input'}}}
+            return make_response("", 200)
+
+    return make_response("", 404)
+
+
+if __name__ == "__main__":
+    # export SLACK_SIGNING_SECRET=***
+    # export SLACK_API_TOKEN=xoxb-***
+    # export FLASK_ENV=development
+    # python3 integration_tests/samples/basic_usage/views_2.py
+    app.run("localhost", 3000)
+
+# ngrok http 3000

--- a/slack/web/client.py
+++ b/slack/web/client.py
@@ -7,6 +7,7 @@ from typing import Union, List
 
 import slack.errors as e
 from slack.web.base_client import BaseClient, SlackResponse
+from slack.web.classes.views import View
 
 
 class WebClient(BaseClient):
@@ -1855,7 +1856,7 @@ class WebClient(BaseClient):
         return self.api_call("users.profile.set", json=kwargs)
 
     def views_open(
-        self, *, trigger_id: str, view: dict, **kwargs
+        self, *, trigger_id: str, view: Union[dict, View], **kwargs
     ) -> Union[Future, SlackResponse]:
         """Open a view for a user.
 
@@ -1868,9 +1869,13 @@ class WebClient(BaseClient):
         Args:
             trigger_id (str): Exchange a trigger to post to the user.
                 e.g. '12345.98765.abcd2358fdea'
-            view (dict): The view payload.
+            view (dict or View): The view payload.
         """
-        kwargs.update({"trigger_id": trigger_id, "view": view})
+        kwargs.update({"trigger_id": trigger_id})
+        if isinstance(view, View):
+            kwargs.update({"view": view.to_dict()})
+        else:
+            kwargs.update({"view": view})
         return self.api_call("views.open", json=kwargs)
 
     def views_push(

--- a/tests/web/test_web_client_coverage.py
+++ b/tests/web/test_web_client_coverage.py
@@ -2,6 +2,8 @@ import os
 import unittest
 
 import slack
+from slack.web.classes.blocks import DividerBlock
+from slack.web.classes.views import View
 from tests.web.mock_web_api_server import setup_mock_web_api_server, cleanup_mock_web_api_server
 
 
@@ -273,6 +275,10 @@ class TestWebClientCoverage(unittest.TestCase):
                     self.api_methods_to_call.remove(method(presence="away")["method"])
                 elif method_name == "views_open":
                     self.api_methods_to_call.remove(method(trigger_id="123123", view={})["method"])
+                    method(
+                        trigger_id="123123",
+                        view=View(type="modal", blocks=[DividerBlock()])
+                    )
                 elif method_name == "views_publish":
                     self.api_methods_to_call.remove(method(user_id="U123", view={})["method"])
                 elif method_name == "views_push":


### PR DESCRIPTION
###  Summary

@ruberVulpes
Thank you very much for your great feedback: https://github.com/slackapi/python-slackclient/issues/519#issuecomment-629733995

This pull request adds more validation rules in `View` objects to let developers know errors with more sufficient information. Also, I've updated the `views_open` API method in `WebClient` to accept `View` objects as well.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).