### PR TITLE
Fix #692 superfluous_charset warnings

### DIFF
--- a/slack/web/base_client.py
+++ b/slack/web/base_client.py
@@ -87,7 +87,7 @@ class BaseClient:
         """
         final_headers = {
             "User-Agent": self._get_user_agent(),
-            "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
+            "Content-Type": "application/x-www-form-urlencoded",
         }
 
         if self.token:
@@ -505,7 +505,7 @@ class BaseClient:
             headers["Content-Length"] = len(body)
         elif args["params"]:
             body = urlencode(args["params"])
-            headers["Content-Type"] = "application/x-www-form-urlencoded;charset=utf-8"
+            headers["Content-Type"] = "application/x-www-form-urlencoded"
         else:
             body = None
 
@@ -552,7 +552,7 @@ class BaseClient:
     ):
         headers = {
             "User-Agent": self._get_user_agent(),
-            "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
+            "Content-Type": "application/x-www-form-urlencoded",
         }
         headers.update(self.headers)
         if token:


### PR DESCRIPTION
###  Summary

This pull request fixes #692 by removing an unnecessary part form `Content-Type` header when the value is `application/x-www-form-urlencoded`.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).