### PR TITLE
Fix #705 by modifying SlackResponse to consider None value in dict

### DIFF
--- a/slack/web/slack_response.py
+++ b/slack/web/slack_response.py
@@ -131,9 +131,11 @@ class SlackResponse(object):
         if self._iteration == 1:
             return self
         if self._next_cursor_is_present(self.data):
-            self.req_args.get("params", {}).update(
-                {"cursor": self.data["response_metadata"]["next_cursor"]}
-            )
+            params = self.req_args.get("params", {})
+            if params is None:
+                params = {}
+            params.update({"cursor": self.data["response_metadata"]["next_cursor"]})
+            self.req_args.update({"params": params})
 
             if self._use_sync_aiohttp:
                 # We no longer recommend going with this way

--- a/tests/web/test_web_client.py
+++ b/tests/web/test_web_client.py
@@ -177,3 +177,10 @@ class TestWebClient(unittest.TestCase):
         self.assertIsNone(resp["error"])
         with self.assertRaises(err.SlackApiError):
             await self.async_client.oauth_access(client_id="999.999", client_secret="secret", code="codeeeeeeeeee")
+
+    def test_issue_705_no_param_request_pagination(self):
+        self.client.token = "xoxb-users_list_pagination"
+        users = []
+        for page in self.client.users_list():
+            users = users + page["members"]
+        self.assertTrue(len(users) == 4)


### PR DESCRIPTION
###  Summary

This pull request fixes #705 by modifying `SlackRepsonse` to consider possible None values in `req_args` dict.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).