### PR TITLE
Fix #708 default_to_current_conversation in (multi_)conversations_select

### DIFF
--- a/integration_tests/samples/basic_usage/views_default_to_current_conversation.py
+++ b/integration_tests/samples/basic_usage/views_default_to_current_conversation.py
@@ -1,0 +1,107 @@
+# ------------------
+# Only for running this script here
+import json
+import logging
+import sys
+from os.path import dirname
+
+sys.path.insert(1, f"{dirname(__file__)}/../../..")
+logging.basicConfig(level=logging.DEBUG)
+
+# ---------------------
+# Slack WebClient
+# ---------------------
+
+import os
+
+from slack import WebClient
+from slack.errors import SlackApiError
+from slack.signature import SignatureVerifier
+from slack.web.classes.blocks import InputBlock
+from slack.web.classes.elements import ConversationMultiSelectElement, ConversationSelectElement
+from slack.web.classes.objects import PlainTextObject
+from slack.web.classes.views import View
+
+client = WebClient(token=os.environ["SLACK_API_TOKEN"])
+signature_verifier = SignatureVerifier(os.environ["SLACK_SIGNING_SECRET"])
+
+# ---------------------
+# Flask App
+# ---------------------
+
+# pip3 install flask
+from flask import Flask, request, make_response
+
+app = Flask(__name__)
+
+
+def open_modal(trigger_id: str):
+    try:
+        view = View(
+            type="modal",
+            callback_id="modal-id",
+            title=PlainTextObject(text="Awesome Modal"),
+            submit=PlainTextObject(text="Submit"),
+            close=PlainTextObject(text="Cancel"),
+            blocks=[
+                InputBlock(
+                    block_id="b-id-1",
+                    label=PlainTextObject(text="Input label"),
+                    element=ConversationSelectElement(
+                        action_id="a",
+                        default_to_current_conversation=True,
+                    )
+                ),
+                InputBlock(
+                    block_id="b-id-2",
+                    label=PlainTextObject(text="Input label"),
+                    element=ConversationMultiSelectElement(
+                        action_id="a",
+                        max_selected_items=2,
+                        default_to_current_conversation=True,
+                    )
+                ),
+            ]
+        )
+        response = client.views_open(
+            trigger_id=trigger_id,
+            view=view
+        )
+        return make_response("", 200)
+    except SlackApiError as e:
+        code = e.response["error"]
+        return make_response(f"Failed to open a modal due to {code}", 200)
+
+
+@app.route("/slack/events", methods=["POST"])
+def slack_app():
+    if not signature_verifier.is_valid_request(request.get_data(), request.headers):
+        return make_response("invalid request", 403)
+
+    if "command" in request.form \
+        and request.form["command"] == "/view":
+        trigger_id = request.form["trigger_id"]
+        return open_modal(trigger_id)
+
+    elif "payload" in request.form:
+        payload = json.loads(request.form["payload"])
+        if payload["type"] == "view_submission" \
+            and payload["view"]["callback_id"] == "modal-id":
+            submitted_data = payload["view"]["state"]["values"]
+            print(submitted_data)  # {'b-id': {'a-id': {'type': 'plain_text_input', 'value': 'your input'}}}
+            return make_response("", 200)
+        if payload["type"] == "shortcut" \
+            and payload["callback_id"] == "view-test":
+            return open_modal(payload["trigger_id"])
+
+    return make_response("", 404)
+
+
+if __name__ == "__main__":
+    # export SLACK_SIGNING_SECRET=***
+    # export SLACK_API_TOKEN=xoxb-***
+    # export FLASK_ENV=development
+    # python3 integration_tests/samples/basic_usage/views_default_to_current_conversation.py
+    app.run("localhost", 3000)
+
+# ngrok http 3000

--- a/slack/web/classes/elements.py
+++ b/slack/web/classes/elements.py
@@ -786,7 +786,12 @@ class ConversationSelectElement(InputInteractiveElement):
     @property
     def attributes(self) -> Set[str]:
         return super().attributes.union(
-            {"initial_conversation", "response_url_enabled", "filter"}
+            {
+                "initial_conversation",
+                "response_url_enabled",
+                "filter",
+                "default_to_current_conversation",
+            }
         )
 
     def __init__(
@@ -797,6 +802,7 @@ class ConversationSelectElement(InputInteractiveElement):
         initial_conversation: Optional[str] = None,
         confirm: Optional[Union[dict, ConfirmObject]] = None,
         response_url_enabled: Optional[bool] = None,
+        default_to_current_conversation: Optional[bool] = None,
         filter: Optional[ConversationFilter] = None,
         **others: dict,
     ):
@@ -815,6 +821,7 @@ class ConversationSelectElement(InputInteractiveElement):
 
         self.initial_conversation = initial_conversation
         self.response_url_enabled = response_url_enabled
+        self.default_to_current_conversation = default_to_current_conversation
         self.filter = filter
 
 
@@ -824,7 +831,12 @@ class ConversationMultiSelectElement(InputInteractiveElement):
     @property
     def attributes(self) -> Set[str]:
         return super().attributes.union(
-            {"initial_conversations", "max_selected_items", "filter"}
+            {
+                "initial_conversations",
+                "max_selected_items",
+                "default_to_current_conversation",
+                "filter",
+            }
         )
 
     def __init__(
@@ -835,6 +847,7 @@ class ConversationMultiSelectElement(InputInteractiveElement):
         initial_conversations: Optional[List[str]] = None,
         confirm: Optional[Union[dict, ConfirmObject]] = None,
         max_selected_items: Optional[int] = None,
+        default_to_current_conversation: Optional[bool] = None,
         filter: Optional[Union[dict, ConversationFilter]] = None,
         **others: dict,
     ):
@@ -853,6 +866,7 @@ class ConversationMultiSelectElement(InputInteractiveElement):
 
         self.initial_conversations = initial_conversations
         self.max_selected_items = max_selected_items
+        self.default_to_current_conversation = default_to_current_conversation
         self.filter = ConversationFilter.parse(filter)
 
 

--- a/tests/web/classes/test_elements.py
+++ b/tests/web/classes/test_elements.py
@@ -652,6 +652,7 @@ class ConversationSelectMultiElementTests(unittest.TestCase):
             },
             "initial_conversations": ["C123", "C234"],
             "max_selected_items": 2,
+            "default_to_current_conversation": True,
             "filter": {
                 "include": [
                     "public",
@@ -674,6 +675,7 @@ class ConversationSelectElementTests(unittest.TestCase):
             },
             "initial_conversation": "C123",
             "response_url_enabled": True,
+            "default_to_current_conversation": True,
             "filter": {
                 "include": [
                     "public",


### PR DESCRIPTION
###  Summary

This pull request fixes #708 by adding the `default_to_current_conversation` flag to (multi_)conversations_select block elements. This enables developers to fill the current conversation in the `initial_converstaion` when opening a modal (from shortcuts, buttons, and slash commands).

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).