### PR TITLE
Fix #536 Allow Tokens to be specified per request

### DIFF
--- a/integration_tests/samples/oauth/oauth_v2.py
+++ b/integration_tests/samples/oauth/oauth_v2.py
@@ -97,7 +97,7 @@ def oauth_callback():
         state = request.args["state"]
         if state_service.consume(state):
             code = request.args["code"]
-            client = WebClient(token="")  # not prepared token needed for this app
+            client = WebClient()  # not prepared token needed for this app
             response = client.oauth_v2_access(
                 client_id=client_id,
                 client_secret=client_secret,

--- a/integration_tests/samples/oauth/oauth_v2.py
+++ b/integration_tests/samples/oauth/oauth_v2.py
@@ -97,7 +97,7 @@ def oauth_callback():
         state = request.args["state"]
         if state_service.consume(state):
             code = request.args["code"]
-            client = WebClient()  # not prepared token needed for this app
+            client = WebClient()  # no prepared token needed for this app
             response = client.oauth_v2_access(
                 client_id=client_id,
                 client_secret=client_secret,

--- a/integration_tests/web/test_web_client.py
+++ b/integration_tests/web/test_web_client.py
@@ -220,6 +220,45 @@ class TestWebClient(unittest.TestCase):
         deletion = client.files_delete(file=upload["file"]["id"])
         self.assertIsNotNone(deletion)
 
+    def test_uploading_file_with_token_param(self):
+        client = WebClient()
+        current_dir = os.path.dirname(__file__)
+        file = f"{current_dir}/../../tests/data/slack_logo.png"
+        upload = client.files_upload(
+            token=self.bot_token,
+            channels=self.channel_id,
+            title="Good Old Slack Logo",
+            filename="slack_logo.png",
+            file=file,
+        )
+        self.assertIsNotNone(upload)
+
+        deletion = client.files_delete(
+            token=self.bot_token,
+            file=upload["file"]["id"],
+        )
+        self.assertIsNotNone(deletion)
+
+    @async_test
+    async def test_uploading_file_with_token_param_async(self):
+        client = WebClient(run_async=True)
+        current_dir = os.path.dirname(__file__)
+        file = f"{current_dir}/../../tests/data/slack_logo.png"
+        upload = await client.files_upload(
+            token=self.bot_token,
+            channels=self.channel_id,
+            title="Good Old Slack Logo",
+            filename="slack_logo.png",
+            file=file,
+        )
+        self.assertIsNotNone(upload)
+
+        deletion = client.files_delete(
+            token=self.bot_token,
+            file=upload["file"]["id"],
+        )
+        self.assertIsNotNone(deletion)
+
     # -------------------------
     # pagination
 

--- a/slack/web/base_client.py
+++ b/slack/web/base_client.py
@@ -69,7 +69,12 @@ class BaseClient:
             return loop
 
     def _get_headers(
-        self, has_json: bool, has_files: bool, request_specific_headers: Optional[dict]
+        self,
+        *,
+        token: Optional[str],
+        has_json: bool,
+        has_files: bool,
+        request_specific_headers: Optional[dict],
     ):
         """Constructs the headers need for a request.
         Args:
@@ -90,8 +95,8 @@ class BaseClient:
             "Content-Type": "application/x-www-form-urlencoded",
         }
 
-        if self.token:
-            final_headers.update({"Authorization": "Bearer {}".format(self.token)})
+        if token:
+            final_headers.update({"Authorization": "Bearer {}".format(token)})
 
         # Merge headers specified at client initialization.
         final_headers.update(self.headers)
@@ -169,8 +174,18 @@ class BaseClient:
         if params is not None and isinstance(params, dict):
             params = {k: v for k, v in params.items() if v is not None}
 
+        token: Optional[str] = self.token
+        if params is not None and "token" in params:
+            token = params.pop("token")
+        if json is not None and "token" in json:
+            token = json.pop("token")
         req_args = {
-            "headers": self._get_headers(has_json, has_files, headers),
+            "headers": self._get_headers(
+                token=token,
+                has_json=has_json,
+                has_files=has_files,
+                request_specific_headers=headers,
+            ),
             "data": data,
             "files": files,
             "params": params,

--- a/tests/web/test_web_client.py
+++ b/tests/web/test_web_client.py
@@ -158,10 +158,18 @@ class TestWebClient(unittest.TestCase):
     @async_test
     async def test_issue_690_oauth_v2_access_async(self):
         self.async_client.token = ""
-        resp = await self.async_client.oauth_v2_access(client_id="111.222", client_secret="secret", code="codeeeeeeeeee")
+        resp = await self.async_client.oauth_v2_access(
+            client_id="111.222",
+            client_secret="secret",
+            code="codeeeeeeeeee",
+        )
         self.assertIsNone(resp["error"])
         with self.assertRaises(err.SlackApiError):
-            await self.async_client.oauth_v2_access(client_id="999.999", client_secret="secret", code="codeeeeeeeeee")
+            await self.async_client.oauth_v2_access(
+                client_id="999.999",
+                client_secret="secret",
+                code="codeeeeeeeeee",
+            )
 
     def test_issue_690_oauth_access(self):
         self.client.token = ""
@@ -184,3 +192,22 @@ class TestWebClient(unittest.TestCase):
         for page in self.client.users_list():
             users = users + page["members"]
         self.assertTrue(len(users) == 4)
+
+    def test_token_param(self):
+        client = WebClient(base_url="http://localhost:8888")
+        with self.assertRaises(err.SlackApiError):
+            client.users_list()
+        resp = client.users_list(token="xoxb-users_list_pagination")
+        self.assertIsNone(resp["error"])
+        with self.assertRaises(err.SlackApiError):
+            client.users_list()
+
+    @async_test
+    async def test_token_param_async(self):
+        client = WebClient(base_url="http://localhost:8888", run_async=True)
+        with self.assertRaises(err.SlackApiError):
+            await client.users_list()
+        resp = await client.users_list(token="xoxb-users_list_pagination")
+        self.assertIsNone(resp["error"])
+        with self.assertRaises(err.SlackApiError):
+            await client.users_list()


### PR DESCRIPTION
###  Summary

This pull request fixes #536 by adding token argument support in `BaseClient#api_call` method. This change enables developers to pass an access token for each request.

```python
from slack import WebClient

bot_token = "xoxb-***"
client = WebClient(token=bot_token)

user_token = "xoxp-***"
result = client.search_all(token=user_token, query="pickleface")
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).