### PR TITLE
Fix #714 by adding proxy support for sync WebClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,9 @@ For sync requests, see the [urllib SSL documentation](https://docs.python.org/3/
 
 A proxy is supported when making async requests, pass the `proxy` option, supported by both the RTM and the Web client.
 
-For more information, see [AIOHttp Proxy documentation](https://docs.aiohttp.org/en/stable/client_advanced.html#proxy-support).
+For async requests, see [AIOHttp Proxy documentation](https://docs.aiohttp.org/en/stable/client_advanced.html#proxy-support).
+
+For sync requests, setting either `HTTPS_PROXY` env variable or the `proxy` option works.
 
 #### DNS performance
 

--- a/integration_tests/samples/issues/issue_714.py
+++ b/integration_tests/samples/issues/issue_714.py
@@ -1,0 +1,53 @@
+# ------------------
+# Only for running this script here
+import asyncio
+import logging
+import sys
+from os.path import dirname
+
+sys.path.insert(1, f"{dirname(__file__)}/../../..")
+logging.basicConfig(level=logging.DEBUG)
+# ------------------
+
+logger = logging.getLogger(__name__)
+
+import os
+from slack import WebClient
+
+# export HTTPS_PROXY=http://localhost:9000
+client = WebClient(token=os.environ["SLACK_API_TOKEN"])
+response = client.auth_test()
+logger.info(f"HTTPS_PROXY response: {response}")
+
+client = WebClient(
+    token=os.environ["SLACK_API_TOKEN"],
+    proxy="http://localhost:9000"
+)
+response = client.auth_test()
+logger.info(f"sync response: {response}")
+
+client = WebClient(
+    token=os.environ["SLACK_API_TOKEN"],
+    proxy="localhost:9000"
+)
+response = client.auth_test()
+logger.info(f"sync response: {response}")
+
+async def async_call():
+    client = WebClient(
+        token=os.environ["SLACK_API_TOKEN"],
+        proxy="http://localhost:9000",
+        run_async=True
+    )
+    response = await client.auth_test()
+    logger.info(f"async response: {response}")
+
+asyncio.run(async_call())
+
+# Terminal A:
+# pip3 install proxy.py
+# proxy --port 9000 --log-level d
+
+# Terminal B:
+# export SLACK_API_TOKEN=xoxb-***
+# python3 integration_tests/samples/issues/issue_714.py

--- a/integration_tests/web/test_issue_714.py
+++ b/integration_tests/web/test_issue_714.py
@@ -1,0 +1,39 @@
+import asyncio
+import os
+import unittest
+from urllib.error import URLError
+
+from aiohttp import ClientConnectorError
+
+from integration_tests.env_variable_names import SLACK_SDK_TEST_BOT_TOKEN
+from integration_tests.helpers import async_test
+from slack import WebClient
+
+
+class TestWebClient(unittest.TestCase):
+
+    def setUp(self):
+        self.proxy = "http://invalid-host:9999"
+        self.bot_token = os.environ[SLACK_SDK_TEST_BOT_TOKEN]
+
+    def tearDown(self):
+        pass
+
+    def test_proxy_failure(self):
+        client: WebClient = WebClient(
+            token=self.bot_token,
+            run_async=False,
+            proxy=self.proxy,
+            loop=asyncio.new_event_loop())
+        with self.assertRaises(URLError):
+            client.auth_test()
+
+    @async_test
+    async def test_proxy_failure_async(self):
+        client: WebClient = WebClient(
+            token=self.bot_token,
+            proxy=self.proxy,
+            run_async=True
+        )
+        with self.assertRaises(ClientConnectorError):
+            await client.auth_test()

--- a/slack/web/base_client.py
+++ b/slack/web/base_client.py
@@ -9,6 +9,7 @@ import json
 import logging
 import mimetypes
 import os
+import re
 import uuid
 import warnings
 from http.client import HTTPResponse
@@ -547,6 +548,16 @@ class BaseClient:
             # which might be a security risk if the URL to open can be manipulated by an external user.
             if url.lower().startswith("http"):
                 req = Request(method="POST", url=url, data=body, headers=headers)
+                if self.proxy is not None:
+                    if isinstance(self.proxy, str):
+                        host = re.sub("^https?://", "", self.proxy)
+                        req.set_proxy(host, "http")
+                        req.set_proxy(host, "https")
+                    else:
+                        raise SlackRequestError(
+                            f"Invalid proxy detected: {self.proxy} must be a str value"
+                        )
+
                 resp: HTTPResponse = urlopen(req, context=self.ssl)
                 charset = resp.headers.get_content_charset()
                 body: str = resp.read().decode(charset)  # read the response body here


### PR DESCRIPTION
###  Summary

This pull request fixes a regression in v2.6.0 #714 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).