### PR TITLE
Fix #712 by adding timeout arg support in sync WebClient/WebhookClient

### DIFF
--- a/slack/web/base_client.py
+++ b/slack/web/base_client.py
@@ -558,7 +558,9 @@ class BaseClient:
                             f"Invalid proxy detected: {self.proxy} must be a str value"
                         )
 
-                resp: HTTPResponse = urlopen(req, context=self.ssl)
+                resp: HTTPResponse = urlopen(
+                    req, context=self.ssl, timeout=self.timeout
+                )
                 charset = resp.headers.get_content_charset()
                 body: str = resp.read().decode(charset)  # read the response body here
                 return {"status": resp.code, "headers": resp.headers, "body": body}

--- a/slack/webhook/client.py
+++ b/slack/webhook/client.py
@@ -2,6 +2,7 @@ import json
 import logging
 import re
 from http.client import HTTPResponse
+from ssl import SSLContext
 from typing import Dict, Union, List, Optional
 from urllib.error import HTTPError
 from urllib.request import Request, urlopen
@@ -20,17 +21,20 @@ class WebhookClient:
         self,
         url: str,
         timeout: int = 30,
+        ssl: Optional[SSLContext] = None,
         proxy: Optional[str] = None,
         default_headers: Dict[str, str] = {},
     ):
         """API client for Incoming Webhooks and response_url
         :param url: a complete URL to send data (e.g., https://hooks.slack.com/XXX)
         :param timeout: request timeout (in seconds)
+        :param ssl: ssl.SSLContext to use for requests
         :param proxy: proxy URL (e.g., localhost:9000, http://localhost:9000)
         :param default_headers: request headers to add to all requests
         """
         self.url = url
         self.timeout = timeout
+        self.ssl = ssl
         self.proxy = proxy
         self.default_headers = default_headers
 
@@ -107,7 +111,7 @@ class WebhookClient:
             else:
                 raise SlackRequestError(f"Invalid URL detected: {url}")
 
-            resp: HTTPResponse = urlopen(req, timeout=self.timeout)
+            resp: HTTPResponse = urlopen(req, context=self.ssl, timeout=self.timeout)
             charset: str = resp.headers.get_content_charset() or "utf-8"
             response_body: str = resp.read().decode(charset)
             resp = WebhookResponse(

--- a/tests/web/mock_web_api_server.py
+++ b/tests/web/mock_web_api_server.py
@@ -2,6 +2,7 @@ import json
 import logging
 import re
 import threading
+import time
 from http import HTTPStatus
 from http.server import HTTPServer, SimpleHTTPRequestHandler
 from typing import Type
@@ -87,6 +88,13 @@ class MockHandler(SimpleHTTPRequestHandler):
                     self.send_header("Retry-After", 30)
                     self.set_common_headers()
                     self.wfile.write("""{"ok":false,"error":"rate_limited"}""".encode("utf-8"))
+                    self.wfile.close()
+                    return
+
+                if pattern == "timeout":
+                    time.sleep(2)
+                    self.send_response(200)
+                    self.wfile.write("""{"ok":true}""".encode("utf-8"))
                     self.wfile.close()
                     return
 

--- a/tests/web/test_web_client.py
+++ b/tests/web/test_web_client.py
@@ -1,5 +1,6 @@
 import asyncio
 import re
+import socket
 import unittest
 
 import slack.errors as err
@@ -211,3 +212,14 @@ class TestWebClient(unittest.TestCase):
         self.assertIsNone(resp["error"])
         with self.assertRaises(err.SlackApiError):
             await client.users_list()
+
+    def test_timeout_issue_712(self):
+        client = WebClient(base_url="http://localhost:8888", timeout=1)
+        with self.assertRaises(socket.timeout):
+            client.users_list(token="xoxb-timeout")
+
+    @async_test
+    async def test_timeout_issue_712_async(self):
+        client = WebClient(base_url="http://localhost:8888", timeout=1, run_async=True)
+        with self.assertRaises(asyncio.exceptions.TimeoutError):
+            await client.users_list(token="xoxb-timeout")

--- a/tests/web/test_web_client.py
+++ b/tests/web/test_web_client.py
@@ -221,5 +221,5 @@ class TestWebClient(unittest.TestCase):
     @async_test
     async def test_timeout_issue_712_async(self):
         client = WebClient(base_url="http://localhost:8888", timeout=1, run_async=True)
-        with self.assertRaises(asyncio.exceptions.TimeoutError):
+        with self.assertRaises(asyncio.TimeoutError):
             await client.users_list(token="xoxb-timeout")

--- a/tests/webhook/mock_web_api_server.py
+++ b/tests/webhook/mock_web_api_server.py
@@ -1,7 +1,7 @@
-import json
 import logging
 import re
 import threading
+import time
 from http import HTTPStatus
 from http.server import HTTPServer, SimpleHTTPRequestHandler
 from typing import Type
@@ -28,6 +28,9 @@ class MockHandler(SimpleHTTPRequestHandler):
 
     def do_POST(self):
         try:
+            if self.path == "/timeout":
+                time.sleep(2)
+
             body = "ok"
 
             self.send_response(HTTPStatus.OK)

--- a/tests/webhook/test_webhook.py
+++ b/tests/webhook/test_webhook.py
@@ -1,5 +1,6 @@
 import unittest
 import socket
+import urllib
 
 from slack.web.classes.attachments import Attachment, AttachmentField
 from slack.web.classes.blocks import SectionBlock, ImageBlock
@@ -159,4 +160,9 @@ class TestWebhook(unittest.TestCase):
     def test_timeout_issue_712(self):
         client = WebhookClient(url="http://localhost:8888/timeout", timeout=1)
         with self.assertRaises(socket.timeout):
+            client.send_dict({"text": "hello!"})
+
+    def test_proxy_issue_714(self):
+        client = WebhookClient(url="http://localhost:8888", proxy="http://invalid-host:9999")
+        with self.assertRaises(urllib.error.URLError):
             client.send_dict({"text": "hello!"})

--- a/tests/webhook/test_webhook.py
+++ b/tests/webhook/test_webhook.py
@@ -1,4 +1,5 @@
 import unittest
+import socket
 
 from slack.web.classes.attachments import Attachment, AttachmentField
 from slack.web.classes.blocks import SectionBlock, ImageBlock
@@ -154,3 +155,8 @@ class TestWebhook(unittest.TestCase):
         resp: WebhookResponse = client.send_dict({"text": "hello!"})
         self.assertEqual(200, resp.status_code)
         self.assertEqual("ok", resp.body)
+
+    def test_timeout_issue_712(self):
+        client = WebhookClient(url="http://localhost:8888/timeout", timeout=1)
+        with self.assertRaises(socket.timeout):
+            client.send_dict({"text": "hello!"})


### PR DESCRIPTION
###  Summary

This pull request fixes a regression in v2.6.0 #712. Also, it fixes the same issue with `WebhookClient`.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).