### PR TITLE
Text params at "InputBlock" and "View"

### DIFF
--- a/slack/web/classes/blocks.py
+++ b/slack/web/classes/blocks.py
@@ -280,7 +280,7 @@ class InputBlock(Block):
     def __init__(
         self,
         *,
-        label: Union[str, dict, TextObject],
+        label: Union[str, dict, PlainTextObject],
         element: Union[str, dict, InputInteractiveElement],
         block_id: Optional[str] = None,
         hint: Optional[Union[str, dict, PlainTextObject]] = None,
@@ -295,9 +295,9 @@ class InputBlock(Block):
         super().__init__(type=self.type, block_id=block_id)
         show_unknown_key_warning(self, others)
 
-        self.label = TextObject.parse(label)
+        self.label = TextObject.parse(label, default_type=PlainTextObject.type)
         self.element = BlockElement.parse(element)
-        self.hint = PlainTextObject.parse(hint)
+        self.hint = TextObject.parse(hint, default_type=PlainTextObject.type)
         self.optional = optional
 
     @JsonValidator(f"label attribute cannot exceed {label_max_length} characters")

--- a/slack/web/classes/views.py
+++ b/slack/web/classes/views.py
@@ -47,7 +47,7 @@ class View(JsonObject):
         app_id: Optional[str] = None,
         root_view_id: Optional[str] = None,
         previous_view_id: Optional[str] = None,
-        title: Union[dict, PlainTextObject] = None,
+        title: Union[str, dict, PlainTextObject] = None,
         submit: Optional[Union[str, dict, PlainTextObject]] = None,
         close: Optional[Union[str, dict, PlainTextObject]] = None,
         blocks: List[Union[dict, Block]] = [],


### PR DESCRIPTION
###  Summary

Fix some a bug in `InputBlock` label and fix `View` title type (should accept string).

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).