### PR TITLE
Set a specific range of test dependency versions to make builds more stable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ long_description = ""
 with codecs.open(os.path.join(here, "README.md"), encoding="utf-8") as readme:
     long_description = readme.read()
 
-tests_require = ["pytest", "pytest-cov", "codecov", "flake8", "black", "psutil"]
+tests_require = ["pytest>=5,<6", "pytest-cov>=2,<3", "codecov>=2,<3", "flake8>=3,<4", "black", "psutil"]
 
 
 class BaseCommand(Command):


### PR DESCRIPTION
###  Summary

As [this build result shows](https://travis-ci.org/github/slackapi/python-slackclient/jobs/699542509), the CI builds with Python 3.6 and 3.7 started failing due to the mismatching versions of `pytest` and its extensions. 

The direct cause of the error is that somehow the dependency resolver is stick with `pytest` 4.3 even though other dependencies require python 4.6+, plus, it's technically possible to automatically upgrade `pytest` version (as with python 3.8 does). 

Also, how `pip` determines which `pytest` version to use depends on the environment. For instance, we cannot reproduce this behavior on macOS, as far as I know.

To fix this, being more specific about the major versions of dependencies is the easiest and the most straight-forward way. The change in this PR affects only the unit tests for this project. I think it's safe enough to merge immediately. 

Let me merge this. But if anyone has some better idea, I'm happy to switch to an alternative afterward.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).