### PR TITLE
Only require pytest_runner if tests are run

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,9 @@ with codecs.open(os.path.join(here, "README.md"), encoding="utf-8") as readme:
 
 tests_require = ["pytest>=5,<6", "pytest-cov>=2,<3", "codecov>=2,<3", "flake8>=3,<4", "black", "psutil"]
 
+needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
+pytest_runner = ['pytest-runner'] if needs_pytest else []
+
 
 class BaseCommand(Command):
     """Base Command"""
@@ -182,7 +185,7 @@ setup(
     ),
     install_requires=["aiohttp>3.5.2,<4.0.0"],
     extras_require={"optional": ["aiodns>1.0"]},
-    setup_requires=["pytest-runner"],
+    setup_requires=pytest_runner,
     test_suite="tests",
     tests_require=tests_require,
     cmdclass={


### PR DESCRIPTION
Recommendations [1] from upsteam is to not include pytest_runner for all
invocations of setup.py.  This will result in delays and unneeded
downlaods.

[1] https://github.com/pytest-dev/pytest-runner/#considerations


###  Summary

For packaging systems this extra download isn't required.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).