### PR TITLE
Fix #728 by adding bytearray support in files_upload (sync mode)

### DIFF
--- a/integration_tests/web/test_issue_728.py
+++ b/integration_tests/web/test_issue_728.py
@@ -1,0 +1,40 @@
+import os
+import unittest
+
+from integration_tests.env_variable_names import \
+    SLACK_SDK_TEST_BOT_TOKEN, \
+    SLACK_SDK_TEST_WEB_TEST_CHANNEL_ID
+from integration_tests.helpers import async_test
+from slack import WebClient
+
+
+class TestWebClient(unittest.TestCase):
+    """Runs integration tests with real Slack API
+
+    https://github.com/slackapi/python-slackclient/issues/728
+    """
+
+    def setUp(self):
+        if not hasattr(self, "logger"):
+            self.bot_token = os.environ[SLACK_SDK_TEST_BOT_TOKEN]
+            self.channel_ids = ",".join([os.environ[SLACK_SDK_TEST_WEB_TEST_CHANNEL_ID]])
+
+    def tearDown(self):
+        pass
+
+    def test_bytes_for_file_param(self):
+        client: WebClient = WebClient(token=self.bot_token, run_async=False)
+        bytes = bytearray("This is a test", "utf-8")
+        upload = client.files_upload(file=bytes, filename="test.txt", channels=self.channel_ids)
+        self.assertIsNotNone(upload)
+        deletion = client.files_delete(file=upload["file"]["id"])
+        self.assertIsNotNone(deletion)
+
+    @async_test
+    async def test_bytes_for_file_param_async(self):
+        client: WebClient = WebClient(token=self.bot_token, run_async=True)
+        bytes = bytearray("This is a test", "utf-8")
+        upload = await client.files_upload(file=bytes, filename="test.txt", channels=self.channel_ids)
+        self.assertIsNotNone(upload)
+        deletion = await client.files_delete(file=upload["file"]["id"])
+        self.assertIsNotNone(deletion)

--- a/slack/web/base_client.py
+++ b/slack/web/base_client.py
@@ -427,6 +427,8 @@ class BaseClient:
                         f: BinaryIO = open(v.encode("utf-8", "ignore"), "rb")
                         files_to_close.append(f)
                         request_data.update({k: f})
+                    elif isinstance(v, bytearray):
+                        request_data.update({k: io.BytesIO(v)})
                     else:
                         request_data.update({k: v})
 


### PR DESCRIPTION
###  Summary

This pull request fixes #728 by adding `bytearray` type support for file-type parameters. This issue has been an incompatibility issue when using `run_async=False` (the default) mode since v2.6.0

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).