### PR TITLE
DatePickerElement - initial date. Fixed regex error, so it can accept 10 and 20 for day value now.

### DIFF
--- a/slack/web/classes/elements.py
+++ b/slack/web/classes/elements.py
@@ -369,7 +369,7 @@ class DatePickerElement(InputInteractiveElement):
     @JsonValidator("initial_date attribute must be in format 'YYYY-MM-DD'")
     def _validate_initial_date_valid(self):
         return self.initial_date is None or re.match(
-            r"\d{4}-(0[1-9]|1[0-2])-([0-2][1-9]|3[01])", self.initial_date
+            r"\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])", self.initial_date
         )
 
 

--- a/tests/web/classes/test_elements.py
+++ b/tests/web/classes/test_elements.py
@@ -196,8 +196,8 @@ class DatePickerElementTests(unittest.TestCase):
         self.assertDictEqual(input, DatePickerElement(**input).to_dict())
 
     def test_json(self):
-        for month in range(1 - 12):
-            for day in range(1 - 31):
+        for month in range(1, 12):
+            for day in range(1, 31):
                 date = f"2020-{month:02}-{day:02}"
                 self.assertDictEqual(
                     {


### PR DESCRIPTION
Fix for the issue:
https://github.com/slackapi/python-slackclient/issues/744