### PR TITLE
Fix #718 by handling unexpected response body format

### DIFF
--- a/slack/web/base_client.py
+++ b/slack/web/base_client.py
@@ -303,6 +303,10 @@ class BaseClient:
                     self._logger.debug(
                         f"No response data returned from the following API call: {api_url}."
                     )
+                except json.decoder.JSONDecodeError as e:
+                    message = f"Failed to parse the response body: {str(e)}"
+                    raise err.SlackApiError(message, res)
+
                 response = {
                     "data": data,
                     "headers": res.headers,
@@ -456,7 +460,11 @@ class BaseClient:
 
             response = self._perform_urllib_http_request(url=url, args=request_args)
             if response.get("body", None):
-                response_body_data: dict = json.loads(response["body"])
+                try:
+                    response_body_data: dict = json.loads(response["body"])
+                except json.decoder.JSONDecodeError as e:
+                    message = f"Failed to parse the response body: {str(e)}"
+                    raise err.SlackApiError(message, response)
             else:
                 response_body_data: dict = None
 

--- a/tests/web/mock_web_api_server.py
+++ b/tests/web/mock_web_api_server.py
@@ -18,6 +18,8 @@ class MockHandler(SimpleHTTPRequestHandler):
     pattern_for_language = re.compile("python/(\\S+)", re.IGNORECASE)
     pattern_for_package_identifier = re.compile("slackclient/(\\S+)")
 
+    html_response_body = '<!DOCTYPE HTML PUBLIC \"-//IETF//DTD HTML 2.0//EN\">\n<html><head>\n<title>404 Not Found</title>\n</head><body>\n<h1>Not Found</h1>\n<p>The requested URL /api/team.info was not found on this server.</p>\n</body></html>\n'
+
     def is_valid_user_agent(self):
         user_agent = self.headers["User-Agent"]
         return self.pattern_for_language.search(user_agent) \
@@ -95,6 +97,13 @@ class MockHandler(SimpleHTTPRequestHandler):
                     time.sleep(2)
                     self.send_response(200)
                     self.wfile.write("""{"ok":true}""".encode("utf-8"))
+                    self.wfile.close()
+                    return
+
+                if pattern == "html_response":
+                    self.send_response(404)
+                    self.set_common_headers()
+                    self.wfile.write(self.html_response_body.encode("utf-8"))
                     self.wfile.close()
                     return
 

--- a/tests/web/test_web_client.py
+++ b/tests/web/test_web_client.py
@@ -244,3 +244,22 @@ class TestWebClient(unittest.TestCase):
         loop.run_until_complete(issue_645())
         gc.collect()  # force Python to gc unclosed client session
         self.assertFalse(session_unclosed, "Unclosed client session")
+
+    def test_html_response_body_issue_718(self):
+        client = WebClient(base_url="http://localhost:8888")
+        try:
+            client.users_list(token="xoxb-html_response")
+            self.fail("SlackApiError expected here")
+        except err.SlackApiError as e:
+            self.assertTrue(
+                str(e).startswith("Failed to parse the response body: Expecting value: line 1 column 1 (char 0)"), e)
+
+    @async_test
+    async def test_html_response_body_issue_718_async(self):
+        client = WebClient(base_url="http://localhost:8888", run_async=True)
+        try:
+            await client.users_list(token="xoxb-html_response")
+            self.fail("SlackApiError expected here")
+        except err.SlackApiError as e:
+            self.assertTrue(
+                str(e).startswith("Failed to parse the response body: Expecting value: line 1 column 1 (char 0)"), e)


### PR DESCRIPTION
###  Summary

This pull request fixes #718 by adding the logic to handle non-JSON response body data in `WebClient` (both sync and async). Although the situation almost never happens, raising only the errors defined in this SDK is more developer-friendly. Refer to the issue for details and use cases.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).