### PR TITLE
Fix #733 Better error handling when getting TimeoutError in RTMClient#start()

### DIFF
--- a/slack/rtm/client.py
+++ b/slack/rtm/client.py
@@ -401,6 +401,10 @@ class RTMClient(object):
                 # True
                 message = await self._websocket.receive(timeout=1)
             except asyncio.TimeoutError:
+                if self._websocket is None:
+                    # For some reason, the connection unexpectedly doesn't exist here.
+                    # In the case, this method can do nothing.
+                    return
                 if not self._websocket.closed:
                     # We didn't receive a message within the timeout interval, but
                     # aiohttp hasn't closed the socket, so ping responses must still be


### PR DESCRIPTION
###  Summary

This pull request fixes #733. As the situation is not so easy to reproduce, I didn't write unit tests for this change. I'm sure the change is safe enough, though.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).