### PR TITLE
Fix #769 by supporting prefix/suffix for User-Agent

### DIFF
--- a/slack/web/__init__.py
+++ b/slack/web/__init__.py
@@ -1,6 +1,6 @@
 import platform
 import sys
-from typing import Dict
+from typing import Dict, Optional
 
 import slack.version as slack_version
 
@@ -26,7 +26,7 @@ def convert_bool_to_0_or_1(params: Dict[str, any]) -> Dict[str, any]:
     return None
 
 
-def get_user_agent():
+def get_user_agent(prefix: Optional[str] = None, suffix: Optional[str] = None):
     """Construct the user-agent header with the package info,
     Python version and OS version.
 
@@ -39,4 +39,6 @@ def get_user_agent():
     python_version = "Python/{v.major}.{v.minor}.{v.micro}".format(v=sys.version_info)
     system_info = "{0}/{1}".format(platform.system(), platform.release())
     user_agent_string = " ".join([python_version, client, system_info])
-    return user_agent_string
+    prefix = f"{prefix} " if prefix else ""
+    suffix = f" {suffix}" if suffix else ""
+    return prefix + user_agent_string + suffix

--- a/slack/web/async_internal_utils.py
+++ b/slack/web/async_internal_utils.py
@@ -60,9 +60,10 @@ def _get_headers(
             }
     """
     final_headers = {
-        "User-Agent": get_user_agent(),
         "Content-Type": "application/x-www-form-urlencoded",
     }
+    if headers is None or "User-Agent" not in headers:
+        final_headers["User-Agent"] = get_user_agent()
 
     if token:
         final_headers.update({"Authorization": "Bearer {}".format(token)})

--- a/slack/web/base_client.py
+++ b/slack/web/base_client.py
@@ -51,6 +51,8 @@ class BaseClient:
         use_sync_aiohttp: bool = False,
         session: Optional[aiohttp.ClientSession] = None,
         headers: Optional[dict] = None,
+        user_agent_prefix: Optional[str] = None,
+        user_agent_suffix: Optional[str] = None,
     ):
         self.token = None if token is None else token.strip()
         self.base_url = base_url
@@ -61,6 +63,9 @@ class BaseClient:
         self.use_sync_aiohttp = use_sync_aiohttp
         self.session = session
         self.headers = headers or {}
+        self.headers["User-Agent"] = get_user_agent(
+            user_agent_prefix, user_agent_suffix
+        )
         self._logger = logging.getLogger(__name__)
         self._event_loop = loop
 
@@ -110,6 +115,9 @@ class BaseClient:
         """
 
         api_url = _get_url(self.base_url, api_method)
+        headers = headers or {}
+        headers.update(self.headers)
+
         req_args = _build_req_args(
             token=self.token,
             http_verb=http_verb,
@@ -483,10 +491,7 @@ class BaseClient:
     def _build_urllib_request_headers(
         self, token: str, has_json: bool, has_files: bool, additional_headers: dict
     ) -> Dict[str, str]:
-        headers = {
-            "User-Agent": get_user_agent(),
-            "Content-Type": "application/x-www-form-urlencoded",
-        }
+        headers = {"Content-Type": "application/x-www-form-urlencoded"}
         headers.update(self.headers)
         if token:
             headers.update({"Authorization": "Bearer {}".format(token)})

--- a/slack/webhook/async_client.py
+++ b/slack/webhook/async_client.py
@@ -9,6 +9,7 @@ from aiohttp import BasicAuth, ClientSession
 from slack.errors import SlackApiError
 from .internal_utils import _debug_log_response, _build_request_headers, _build_body
 from .webhook_response import WebhookResponse
+from ..web import get_user_agent
 from ..web.classes.attachments import Attachment
 from ..web.classes.blocks import Block
 
@@ -26,6 +27,8 @@ class AsyncWebhookClient:
         trust_env_in_session: bool = False,
         auth: Optional[BasicAuth] = None,
         default_headers: Optional[Dict[str, str]] = None,
+        user_agent_prefix: Optional[str] = None,
+        user_agent_suffix: Optional[str] = None,
     ):
         """API client for Incoming Webhooks and response_url
         :param url: a complete URL to send data (e.g., https://hooks.slack.com/XXX)
@@ -36,6 +39,8 @@ class AsyncWebhookClient:
         :param trust_env_in_session: True/False for aiohttp.ClientSession
         :param auth: Basic auth info for aiohttp.ClientSession
         :param default_headers: request headers to add to all requests
+        :param user_agent_prefix: prefix for User-Agent header value
+        :param user_agent_suffix: suffix for User-Agent header value
         """
         self.url = url
         self.timeout = timeout
@@ -45,6 +50,9 @@ class AsyncWebhookClient:
         self.session = session
         self.auth = auth
         self.default_headers = default_headers if default_headers else {}
+        self.default_headers["User-Agent"] = get_user_agent(
+            user_agent_prefix, user_agent_suffix
+        )
 
     async def send(
         self,

--- a/slack/webhook/client.py
+++ b/slack/webhook/client.py
@@ -10,6 +10,7 @@ from urllib.request import Request, urlopen
 from slack.errors import SlackRequestError
 from .internal_utils import _build_body, _build_request_headers, _debug_log_response
 from .webhook_response import WebhookResponse
+from ..web import get_user_agent
 from ..web.classes.attachments import Attachment
 from ..web.classes.blocks import Block
 
@@ -24,6 +25,8 @@ class WebhookClient:
         ssl: Optional[SSLContext] = None,
         proxy: Optional[str] = None,
         default_headers: Optional[Dict[str, str]] = None,
+        user_agent_prefix: Optional[str] = None,
+        user_agent_suffix: Optional[str] = None,
     ):
         """API client for Incoming Webhooks and response_url
         :param url: a complete URL to send data (e.g., https://hooks.slack.com/XXX)
@@ -31,12 +34,17 @@ class WebhookClient:
         :param ssl: ssl.SSLContext to use for requests
         :param proxy: proxy URL (e.g., localhost:9000, http://localhost:9000)
         :param default_headers: request headers to add to all requests
+        :param user_agent_prefix: prefix for User-Agent header value
+        :param user_agent_suffix: suffix for User-Agent header value
         """
         self.url = url
         self.timeout = timeout
         self.ssl = ssl
         self.proxy = proxy
         self.default_headers = default_headers if default_headers else {}
+        self.default_headers["User-Agent"] = get_user_agent(
+            user_agent_prefix, user_agent_suffix
+        )
 
     def send(
         self,

--- a/slack/webhook/internal_utils.py
+++ b/slack/webhook/internal_utils.py
@@ -14,15 +14,17 @@ def _build_body(original_body: Dict[str, any]) -> Dict[str, any]:
 
 
 def _build_request_headers(
-    default_headers, additional_headers: Optional[Dict[str, str]],
+    default_headers: Dict[str, str], additional_headers: Optional[Dict[str, str]],
 ) -> Dict[str, str]:
-    if additional_headers is None:
+    if default_headers is None and additional_headers is None:
         return {}
 
     request_headers = {
-        "User-Agent": get_user_agent(),
         "Content-Type": "application/json;charset=utf-8",
     }
+    if default_headers is None or "User-Agent" not in default_headers:
+        request_headers["User-Agent"] = get_user_agent()
+
     request_headers.update(default_headers)
     if additional_headers:
         request_headers.update(additional_headers)

--- a/tests/web/mock_web_api_server.py
+++ b/tests/web/mock_web_api_server.py
@@ -107,6 +107,23 @@ class MockHandler(SimpleHTTPRequestHandler):
                     self.wfile.close()
                     return
 
+                if pattern.startswith("user-agent"):
+                    elements = pattern.split(" ")
+                    prefix, suffix = elements[1], elements[-1]
+                    ua: str = self.headers["User-Agent"]
+                    if ua.startswith(prefix) and ua.endswith(suffix):
+                        self.send_response(200)
+                        self.set_common_headers()
+                        self.wfile.write("""{"ok":true}""".encode("utf-8"))
+                        self.wfile.close()
+                        return
+                    else:
+                        self.send_response(400)
+                        self.set_common_headers()
+                        self.wfile.write("""{"ok":false, "error":"invalid_user_agent"}""".encode("utf-8"))
+                        self.wfile.close()
+                        return
+
                 if request_body and "cursor" in request_body:
                     page = request_body["cursor"]
                     pattern = f"{pattern}_{page}"

--- a/tests/web/test_async_web_client.py
+++ b/tests/web/test_async_web_client.py
@@ -1,8 +1,6 @@
 import re
 import unittest
 
-import aiohttp
-
 import slack.errors as err
 from slack import AsyncWebClient
 from tests.helpers import async_test
@@ -130,3 +128,14 @@ class TestAsyncWebClient(unittest.TestCase):
         except err.SlackApiError as e:
             self.assertTrue(
                 str(e).startswith("Failed to parse the response body: Expecting value: line 1 column 1 (char 0)"), e)
+
+    @async_test
+    async def test_user_agent_customization_issue_769_async(self):
+        client = AsyncWebClient(
+            token="xoxb-user-agent this_is test",
+            base_url="http://localhost:8888",
+            user_agent_prefix="this_is",
+            user_agent_suffix="test",
+        )
+        resp = await client.api_test()
+        self.assertTrue(resp["ok"])

--- a/tests/web/test_web_client.py
+++ b/tests/web/test_web_client.py
@@ -263,3 +263,25 @@ class TestWebClient(unittest.TestCase):
         except err.SlackApiError as e:
             self.assertTrue(
                 str(e).startswith("Failed to parse the response body: Expecting value: line 1 column 1 (char 0)"), e)
+
+    def test_user_agent_customization_issue_769(self):
+        client = WebClient(
+            base_url="http://localhost:8888",
+            token="xoxb-user-agent this_is test",
+            user_agent_prefix="this_is",
+            user_agent_suffix="test",
+        )
+        resp = client.api_test()
+        self.assertTrue(resp["ok"])
+
+    @async_test
+    async def test_user_agent_customization_issue_769_async(self):
+        client = WebClient(
+            run_async=True,
+            base_url="http://localhost:8888",
+            token="xoxb-user-agent this_is test",
+            user_agent_prefix="this_is",
+            user_agent_suffix="test",
+        )
+        resp = await client.api_test()
+        self.assertTrue(resp["ok"])

--- a/tests/webhook/mock_web_api_server.py
+++ b/tests/webhook/mock_web_api_server.py
@@ -30,6 +30,25 @@ class MockHandler(SimpleHTTPRequestHandler):
         try:
             if self.path == "/timeout":
                 time.sleep(2)
+
+            # user-agent-this_is-test
+            if self.path.startswith("/user-agent-"):
+                elements = self.path.split("-")
+                prefix, suffix = elements[2], elements[-1]
+                ua: str = self.headers["User-Agent"]
+                if ua.startswith(prefix) and ua.endswith(suffix):
+                    self.send_response(HTTPStatus.OK)
+                    self.set_common_headers()
+                    self.wfile.write("ok".encode("utf-8"))
+                    self.wfile.close()
+                    return
+                else:
+                    self.send_response(HTTPStatus.BAD_REQUEST)
+                    self.set_common_headers()
+                    self.wfile.write("invalid user agent".encode("utf-8"))
+                    self.wfile.close()
+                    return
+
             if self.path == "/error":
                 self.send_response(HTTPStatus.INTERNAL_SERVER_ERROR)
                 self.set_common_headers()

--- a/tests/webhook/test_async_webhook.py
+++ b/tests/webhook/test_async_webhook.py
@@ -174,3 +174,13 @@ class TestAsyncWebhook(unittest.TestCase):
         client = AsyncWebhookClient(url="http://localhost:8888", proxy="http://invalid-host:9999")
         with self.assertRaises(Exception):
             await client.send_dict({"text": "hello!"})
+
+    @async_test
+    async def test_user_agent_customization_issue_769(self):
+        client = AsyncWebhookClient(
+            url="http://localhost:8888/user-agent-this_is-test",
+            user_agent_prefix="this_is",
+            user_agent_suffix="test",
+        )
+        resp = await client.send_dict({"text": "hi!"})
+        self.assertEqual(resp.body, "ok")

--- a/tests/webhook/test_webhook.py
+++ b/tests/webhook/test_webhook.py
@@ -172,3 +172,12 @@ class TestWebhook(unittest.TestCase):
         client = WebhookClient(url="http://localhost:8888", proxy="http://invalid-host:9999")
         with self.assertRaises(urllib.error.URLError):
             client.send_dict({"text": "hello!"})
+
+    def test_user_agent_customization_issue_769(self):
+        client = WebhookClient(
+            url="http://localhost:8888/user-agent-this_is-test",
+            user_agent_prefix="this_is",
+            user_agent_suffix="test",
+        )
+        resp = client.send_dict({"text": "hi!"})
+        self.assertEqual(resp.body, "ok")


### PR DESCRIPTION
###  Summary

This pull request adds the functionality to add prefix/suffix to User-Agent request header in API requests to Slack API Platform. It fixes the issue #769.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).