### PR TITLE
Correct Block.parse(dict) to support CallBlock

### DIFF
--- a/slack/web/classes/blocks.py
+++ b/slack/web/classes/blocks.py
@@ -78,6 +78,8 @@ class Block(JsonObject):
                     return InputBlock(**block)
                 elif type == FileBlock.type:
                     return FileBlock(**block)
+                elif type == CallBlock.type:
+                    return CallBlock(**block)
                 else:
                     cls.logger.warning(f"Unknown block detected and skipped ({block})")
                     return None

--- a/tests/web/classes/test_blocks.py
+++ b/tests/web/classes/test_blocks.py
@@ -62,6 +62,7 @@ class SectionBlockTests(unittest.TestCase):
             }
         }
         self.assertDictEqual(input, SectionBlock(**input).to_dict())
+        self.assertDictEqual(input, Block.parse(input).to_dict())
 
     def test_document_2(self):
         input = {
@@ -217,6 +218,7 @@ class DividerBlockTests(unittest.TestCase):
             "type": "divider"
         }
         self.assertDictEqual(input, DividerBlock(**input).to_dict())
+        self.assertDictEqual(input, Block.parse(input).to_dict())
 
     def test_json(self):
         self.assertDictEqual(
@@ -252,6 +254,7 @@ class ImageBlockTests(unittest.TestCase):
             "alt_text": "An incredibly cute kitten."
         }
         self.assertDictEqual(input, ImageBlock(**input).to_dict())
+        self.assertDictEqual(input, Block.parse(input).to_dict())
 
     def test_json(self):
         self.assertDictEqual(
@@ -336,6 +339,7 @@ class ActionsBlockTests(unittest.TestCase):
             ]
         }
         self.assertDictEqual(input, ActionsBlock(**input).to_dict())
+        self.assertDictEqual(input, Block.parse(input).to_dict())
 
     def test_document_2(self):
         input = {
@@ -443,6 +447,7 @@ class ContextBlockTests(unittest.TestCase):
             ]
         }
         self.assertDictEqual(input, ContextBlock(**input).to_dict())
+        self.assertDictEqual(input, Block.parse(input).to_dict())
 
     def test_basic_json(self):
         self.elements = [
@@ -604,6 +609,7 @@ class InputBlockTests(unittest.TestCase):
         ]
         for input in blocks:
             self.assertDictEqual(input, InputBlock(**input).to_dict())
+            self.assertDictEqual(input, Block.parse(input).to_dict())
 
 
 # ----------------------------------------------
@@ -618,6 +624,7 @@ class FileBlockTests(unittest.TestCase):
             "source": "remote",
         }
         self.assertDictEqual(input, FileBlock(**input).to_dict())
+        self.assertDictEqual(input, Block.parse(input).to_dict())
 
 # ----------------------------------------------
 # Call
@@ -688,3 +695,4 @@ class CallBlockTests(unittest.TestCase):
             }
         }
         self.assertDictEqual(input, CallBlock(**input).to_dict())
+        self.assertDictEqual(input, Block.parse(input).to_dict())


### PR DESCRIPTION
###  Summary

While reviewing #768 , I found that `CallBlock` is not yet supported in `Block.parse(dict)` method. The block class was introduced by #704. I missed changing the class method in the PR.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).