### PR TITLE
Fix a link to the Static options documentation

### DIFF
--- a/slack/web/classes/elements.py
+++ b/slack/web/classes/elements.py
@@ -444,7 +444,7 @@ class StaticSelectElement(InputInteractiveElement):
         **others: dict,
     ):
         """This is the simplest form of select menu, with a static list of options passed in when defining the element.
-        ps://api.slack.com/reference/block-kit/block-elements#static_select
+        https://api.slack.com/reference/block-kit/block-elements#static_select
         """
         super().__init__(
             type=self.type,


### PR DESCRIPTION
## Summary

This PR aims to fix a broken link.

### Category

- [ ] **slack.web.WebClient** (Web API client)
- [ ] **slack.webhook.WebHookClient** (Incoming Webhook, response_url sender)
- [x] **slack.web.classes** (UI component builders)
- [ ] **slack.rtm.RTMClient** (RTM client)

## Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes.
