### PR TITLE
Minor improvements to admin.conversations.* support

### DIFF
--- a/integration_tests/web/test_admin_conversations.py
+++ b/integration_tests/web/test_admin_conversations.py
@@ -62,7 +62,13 @@ class TestWebClient(unittest.TestCase):
             channel_id=created_channel_id,
             name=self.channel_rename,
         ))
-        self.assertIsNotNone(client.admin_conversations_search())
+        search_result = client.admin_conversations_search(
+            limit=1,
+            sort="member_count",
+            sort_dir="desc",
+        )
+        self.assertIsNotNone(search_result.data["next_cursor"])
+        self.assertIsNotNone(search_result.data["conversations"])
 
         self.assertIsNotNone(client.admin_conversations_getConversationPrefs(
             channel_id=created_channel_id,

--- a/slack/web/async_client.py
+++ b/slack/web/async_client.py
@@ -122,6 +122,150 @@ class AsyncWebClient(AsyncBaseClient):
             "admin.apps.restricted.list", http_verb="GET", params=kwargs
         )
 
+    async def admin_conversations_create(
+        self, *, is_private: bool, name: str, **kwargs
+    ) -> AsyncSlackResponse:
+        """Create a public or private channel-based conversation.
+
+        Args:
+            is_private (bool): When true, creates a private channel instead of a public channel
+            name (str): Name of the public or private channel to create.
+            org_wide (bool): When true, the channel will be available org-wide.
+                Note: if the channel is not org_wide=true, you must specify a team_id for this channel
+            team_id (str): The workspace to create the channel in.
+                Note: this argument is required unless you set org_wide=true.
+
+        """
+        kwargs.update({"is_private": is_private, "name": name})
+        return await self.api_call("admin.conversations.create", json=kwargs)
+
+    async def admin_conversations_delete(
+        self, *, channel_id: str, **kwargs
+    ) -> AsyncSlackResponse:
+        """Delete a public or private channel.
+
+        Args:
+            channel_id (str): The channel to delete.
+
+        """
+        kwargs.update({"channel_id": channel_id})
+        return await self.api_call("admin.conversations.delete", json=kwargs)
+
+    async def admin_conversations_invite(
+        self, *, channel_id: str, user_ids: Union[str, List[str]], **kwargs
+    ) -> AsyncSlackResponse:
+        """Invite a user to a public or private channel.
+
+        Args:
+            channel_id (str): The channel that the users will be invited to.
+            user_ids (str or list): The users to invite.
+        """
+        kwargs.update({"channel_id": channel_id})
+        if isinstance(user_ids, list):
+            kwargs.update({"user_ids": ",".join(user_ids)})
+        else:
+            kwargs.update({"user_ids": user_ids})
+        # NOTE: the endpoint is unable to handle Content-Type: application/json as of Sep 3, 2020.
+        return await self.api_call("admin.conversations.invite", params=kwargs)
+
+    async def admin_conversations_archive(
+        self, *, channel_id: str, **kwargs
+    ) -> AsyncSlackResponse:
+        """Archive a public or private channel.
+
+        Args:
+            channel_id (str): The channel to archive.
+        """
+        kwargs.update({"channel_id": channel_id})
+        return await self.api_call("admin.conversations.archive", json=kwargs)
+
+    async def admin_conversations_unarchive(
+        self, *, channel_id: str, **kwargs
+    ) -> AsyncSlackResponse:
+        """Unarchive a public or private channel.
+
+        Args:
+            channel_id (str): The channel to unarchive.
+        """
+        kwargs.update({"channel_id": channel_id})
+        return await self.api_call("admin.conversations.unarchive", json=kwargs)
+
+    async def admin_conversations_rename(
+        self, *, channel_id: str, name: str, **kwargs
+    ) -> AsyncSlackResponse:
+        """Rename a public or private channel.
+
+        Args:
+            channel_id (str): The channel to rename.
+            name (str): The name to rename the channel to.
+        """
+        kwargs.update({"channel_id": channel_id, "name": name})
+        return await self.api_call("admin.conversations.rename", json=kwargs)
+
+    async def admin_conversations_search(self, **kwargs) -> AsyncSlackResponse:
+        """Search for public or private channels in an Enterprise organization."""
+        return await self.api_call("admin.conversations.search", json=kwargs)
+
+    async def admin_conversations_convertToPrivate(
+        self, *, channel_id: str, **kwargs
+    ) -> AsyncSlackResponse:
+        """Convert a public channel to a private channel.
+
+        Args:
+            channel_id (str): The channel to convert to private.
+        """
+        kwargs.update({"channel_id": channel_id})
+        return await self.api_call("admin.conversations.convertToPrivate", json=kwargs)
+
+    async def admin_conversations_setConversationPrefs(
+        self, *, channel_id: str, prefs: Union[str, dict], **kwargs
+    ) -> AsyncSlackResponse:
+        """Set the posting permissions for a public or private channel.
+
+        Args:
+            channel_id (str): The channel to set the prefs for
+            prefs (str or dict): The prefs for this channel in a stringified JSON format.
+        """
+        kwargs.update({"channel_id": channel_id, "prefs": prefs})
+        return await self.api_call(
+            "admin.conversations.setConversationPrefs", json=kwargs
+        )
+
+    async def admin_conversations_getConversationPrefs(
+        self, *, channel_id: str, **kwargs
+    ) -> AsyncSlackResponse:
+        """Get conversation preferences for a public or private channel.
+
+        Args:
+            channel_id (str): The channel to get the preferences for.
+        """
+        kwargs.update({"channel_id": channel_id})
+        return await self.api_call(
+            "admin.conversations.getConversationPrefs", json=kwargs
+        )
+
+    async def admin_conversations_disconnectShared(
+        self, *, channel_id: str, **kwargs
+    ) -> AsyncSlackResponse:
+        """Disconnect a connected channel from one or more workspaces.
+
+        Args:
+            channel_id (str): The channel to be disconnected from some workspaces.
+        """
+        kwargs.update({"channel_id": channel_id})
+        return await self.api_call("admin.conversations.disconnectShared", json=kwargs)
+
+    async def admin_conversations_ekm_listOriginalConnectedChannelInfo(
+        self, **kwargs
+    ) -> AsyncSlackResponse:
+        """List all disconnected channels—i.e.,
+        channels that were once connected to other workspaces and then disconnected—and
+        the corresponding original channel IDs for key revocation with EKM.
+        """
+        return await self.api_call(
+            "admin.conversations.ekm.listOriginalConnectedChannelInfo", params=kwargs
+        )
+
     async def admin_conversations_restrictAccess_addGroup(
         self, *, channel_id: str, group_id: str, **kwargs
     ) -> AsyncSlackResponse:
@@ -2176,147 +2320,3 @@ class AsyncWebClient(AsyncBaseClient):
         else:
             kwargs.update({"view": view})
         return await self.api_call("views.publish", json=kwargs)
-
-    async def admin_conversations_create(
-        self, *, is_private: bool, name: str, **kwargs
-    ) -> AsyncSlackResponse:
-        """Create a public or private channel-based conversation.
-
-        Args:
-            is_private (bool): When true, creates a private channel instead of a public channel
-            name (str): Name of the public or private channel to create.
-            org_wide (bool): When true, the channel will be available org-wide.
-                Note: if the channel is not org_wide=true, you must specify a team_id for this channel
-            team_id (str): The workspace to create the channel in.
-                Note: this argument is required unless you set org_wide=true.
-
-        """
-        kwargs.update({"is_private": is_private, "name": name})
-        return await self.api_call("admin.conversations.create", json=kwargs)
-
-    async def admin_conversations_delete(
-        self, *, channel_id: str, **kwargs
-    ) -> AsyncSlackResponse:
-        """Delete a public or private channel.
-
-        Args:
-            channel_id (str): The channel to delete.
-
-        """
-        kwargs.update({"channel_id": channel_id})
-        return await self.api_call("admin.conversations.delete", json=kwargs)
-
-    async def admin_conversations_invite(
-        self, *, channel_id: str, user_ids: Union[str, List[str]], **kwargs
-    ) -> AsyncSlackResponse:
-        """Invite a user to a public or private channel.
-
-        Args:
-            channel_id (str): The channel that the users will be invited to.
-            user_ids (str or list): The users to invite.
-        """
-        kwargs.update({"channel_id": channel_id})
-        if isinstance(user_ids, list):
-            kwargs.update({"user_ids": ",".join(user_ids)})
-        else:
-            kwargs.update({"user_ids": user_ids})
-        # NOTE: the endpoint is unable to handle Content-Type: application/json as of Sep 3, 2020.
-        return await self.api_call("admin.conversations.invite", params=kwargs)
-
-    async def admin_conversations_archive(
-        self, *, channel_id: str, **kwargs
-    ) -> AsyncSlackResponse:
-        """Archive a public or private channel.
-
-        Args:
-            channel_id (str): The channel to archive.
-        """
-        kwargs.update({"channel_id": channel_id})
-        return await self.api_call("admin.conversations.archive", json=kwargs)
-
-    async def admin_conversations_unarchive(
-        self, *, channel_id: str, **kwargs
-    ) -> AsyncSlackResponse:
-        """Unarchive a public or private channel.
-
-        Args:
-            channel_id (str): The channel to unarchive.
-        """
-        kwargs.update({"channel_id": channel_id})
-        return await self.api_call("admin.conversations.unarchive", json=kwargs)
-
-    async def admin_conversations_rename(
-        self, *, channel_id: str, name: str, **kwargs
-    ) -> AsyncSlackResponse:
-        """Rename a public or private channel.
-
-        Args:
-            channel_id (str): The channel to rename.
-            name (str): The name to rename the channel to.
-        """
-        kwargs.update({"channel_id": channel_id, "name": name})
-        return await self.api_call("admin.conversations.rename", json=kwargs)
-
-    async def admin_conversations_search(self, **kwargs) -> AsyncSlackResponse:
-        """Search for public or private channels in an Enterprise organization."""
-        return await self.api_call("admin.conversations.search", json=kwargs)
-
-    async def admin_conversations_convertToPrivate(
-        self, *, channel_id: str, **kwargs
-    ) -> AsyncSlackResponse:
-        """Convert a public channel to a private channel.
-
-        Args:
-            channel_id (str): The channel to convert to private.
-        """
-        kwargs.update({"channel_id": channel_id})
-        return await self.api_call("admin.conversations.convertToPrivate", json=kwargs)
-
-    async def admin_conversations_setConversationPrefs(
-        self, *, channel_id: str, prefs: Union[str, dict], **kwargs
-    ) -> AsyncSlackResponse:
-        """Set the posting permissions for a public or private channel.
-
-        Args:
-            channel_id (str): The channel to set the prefs for
-            prefs (str or dict): The prefs for this channel in a stringified JSON format.
-        """
-        kwargs.update({"channel_id": channel_id, "prefs": prefs})
-        return await self.api_call(
-            "admin.conversations.setConversationPrefs", json=kwargs
-        )
-
-    async def admin_conversations_getConversationPrefs(
-        self, *, channel_id: str, **kwargs
-    ) -> AsyncSlackResponse:
-        """Get conversation preferences for a public or private channel.
-
-        Args:
-            channel_id (str): The channel to get the preferences for.
-        """
-        kwargs.update({"channel_id": channel_id})
-        return await self.api_call(
-            "admin.conversations.getConversationPrefs", json=kwargs
-        )
-
-    async def admin_conversations_disconnectShared(
-        self, *, channel_id: str, **kwargs
-    ) -> AsyncSlackResponse:
-        """Disconnect a connected channel from one or more workspaces.
-
-        Args:
-            channel_id (str): The channel to be disconnected from some workspaces.
-        """
-        kwargs.update({"channel_id": channel_id})
-        return await self.api_call("admin.conversations.disconnectShared", json=kwargs)
-
-    async def admin_conversations_ekm_listOriginalConnectedChannelInfo(
-        self, **kwargs
-    ) -> AsyncSlackResponse:
-        """List all disconnected channels—i.e.,
-        channels that were once connected to other workspaces and then disconnected—and
-        the corresponding original channel IDs for key revocation with EKM.
-        """
-        return await self.api_call(
-            "admin.conversations.ekm.listOriginalConnectedChannelInfo", params=kwargs
-        )

--- a/slack/web/client.py
+++ b/slack/web/client.py
@@ -110,6 +110,146 @@ class WebClient(BaseClient):
             "admin.apps.restricted.list", http_verb="GET", params=kwargs
         )
 
+    def admin_conversations_create(
+        self, *, is_private: bool, name: str, **kwargs
+    ) -> Union[Future, SlackResponse]:
+        """Create a public or private channel-based conversation.
+
+        Args:
+            is_private (bool): When true, creates a private channel instead of a public channel
+            name (str): Name of the public or private channel to create.
+            org_wide (bool): When true, the channel will be available org-wide.
+                Note: if the channel is not org_wide=true, you must specify a team_id for this channel
+            team_id (str): The workspace to create the channel in.
+                Note: this argument is required unless you set org_wide=true.
+
+        """
+        kwargs.update({"is_private": is_private, "name": name})
+        return self.api_call("admin.conversations.create", json=kwargs)
+
+    def admin_conversations_delete(
+        self, *, channel_id: str, **kwargs
+    ) -> Union[Future, SlackResponse]:
+        """Delete a public or private channel.
+
+        Args:
+            channel_id (str): The channel to delete.
+
+        """
+        kwargs.update({"channel_id": channel_id})
+        return self.api_call("admin.conversations.delete", json=kwargs)
+
+    def admin_conversations_invite(
+        self, *, channel_id: str, user_ids: Union[str, List[str]], **kwargs
+    ) -> Union[Future, SlackResponse]:
+        """Invite a user to a public or private channel.
+
+        Args:
+            channel_id (str): The channel that the users will be invited to.
+            user_ids (str or list): The users to invite.
+        """
+        kwargs.update({"channel_id": channel_id})
+        if isinstance(user_ids, list):
+            kwargs.update({"user_ids": ",".join(user_ids)})
+        else:
+            kwargs.update({"user_ids": user_ids})
+        # NOTE: the endpoint is unable to handle Content-Type: application/json as of Sep 3, 2020.
+        return self.api_call("admin.conversations.invite", params=kwargs)
+
+    def admin_conversations_archive(
+        self, *, channel_id: str, **kwargs
+    ) -> Union[Future, SlackResponse]:
+        """Archive a public or private channel.
+
+        Args:
+            channel_id (str): The channel to archive.
+        """
+        kwargs.update({"channel_id": channel_id})
+        return self.api_call("admin.conversations.archive", json=kwargs)
+
+    def admin_conversations_unarchive(
+        self, *, channel_id: str, **kwargs
+    ) -> Union[Future, SlackResponse]:
+        """Unarchive a public or private channel.
+
+        Args:
+            channel_id (str): The channel to unarchive.
+        """
+        kwargs.update({"channel_id": channel_id})
+        return self.api_call("admin.conversations.unarchive", json=kwargs)
+
+    def admin_conversations_rename(
+        self, *, channel_id: str, name: str, **kwargs
+    ) -> Union[Future, SlackResponse]:
+        """Rename a public or private channel.
+
+        Args:
+            channel_id (str): The channel to rename.
+            name (str): The name to rename the channel to.
+        """
+        kwargs.update({"channel_id": channel_id, "name": name})
+        return self.api_call("admin.conversations.rename", json=kwargs)
+
+    def admin_conversations_search(self, **kwargs) -> Union[Future, SlackResponse]:
+        """Search for public or private channels in an Enterprise organization."""
+        return self.api_call("admin.conversations.search", json=kwargs)
+
+    def admin_conversations_convertToPrivate(
+        self, *, channel_id: str, **kwargs
+    ) -> Union[Future, SlackResponse]:
+        """Convert a public channel to a private channel.
+
+        Args:
+            channel_id (str): The channel to convert to private.
+        """
+        kwargs.update({"channel_id": channel_id})
+        return self.api_call("admin.conversations.convertToPrivate", json=kwargs)
+
+    def admin_conversations_setConversationPrefs(
+        self, *, channel_id: str, prefs: Union[str, dict], **kwargs
+    ) -> Union[Future, SlackResponse]:
+        """Set the posting permissions for a public or private channel.
+
+        Args:
+            channel_id (str): The channel to set the prefs for
+            prefs (str or dict): The prefs for this channel in a stringified JSON format.
+        """
+        kwargs.update({"channel_id": channel_id, "prefs": prefs})
+        return self.api_call("admin.conversations.setConversationPrefs", json=kwargs)
+
+    def admin_conversations_getConversationPrefs(
+        self, *, channel_id: str, **kwargs
+    ) -> Union[Future, SlackResponse]:
+        """Get conversation preferences for a public or private channel.
+
+        Args:
+            channel_id (str): The channel to get the preferences for.
+        """
+        kwargs.update({"channel_id": channel_id})
+        return self.api_call("admin.conversations.getConversationPrefs", json=kwargs)
+
+    def admin_conversations_disconnectShared(
+        self, *, channel_id: str, **kwargs
+    ) -> Union[Future, SlackResponse]:
+        """Disconnect a connected channel from one or more workspaces.
+
+        Args:
+            channel_id (str): The channel to be disconnected from some workspaces.
+        """
+        kwargs.update({"channel_id": channel_id})
+        return self.api_call("admin.conversations.disconnectShared", json=kwargs)
+
+    def admin_conversations_ekm_listOriginalConnectedChannelInfo(
+        self, **kwargs
+    ) -> Union[Future, SlackResponse]:
+        """List all disconnected channels—i.e.,
+        channels that were once connected to other workspaces and then disconnected—and
+        the corresponding original channel IDs for key revocation with EKM.
+        """
+        return self.api_call(
+            "admin.conversations.ekm.listOriginalConnectedChannelInfo", params=kwargs
+        )
+
     def admin_conversations_restrictAccess_addGroup(
         self, *, channel_id: str, group_id: str, **kwargs
     ) -> Union[Future, SlackResponse]:
@@ -2174,143 +2314,3 @@ class WebClient(BaseClient):
         else:
             kwargs.update({"view": view})
         return self.api_call("views.publish", json=kwargs)
-
-    def admin_conversations_create(
-        self, *, is_private: bool, name: str, **kwargs
-    ) -> Union[Future, SlackResponse]:
-        """Create a public or private channel-based conversation.
-
-        Args:
-            is_private (bool): When true, creates a private channel instead of a public channel
-            name (str): Name of the public or private channel to create.
-            org_wide (bool): When true, the channel will be available org-wide.
-                Note: if the channel is not org_wide=true, you must specify a team_id for this channel
-            team_id (str): The workspace to create the channel in.
-                Note: this argument is required unless you set org_wide=true.
-
-        """
-        kwargs.update({"is_private": is_private, "name": name})
-        return self.api_call("admin.conversations.create", json=kwargs)
-
-    def admin_conversations_delete(
-        self, *, channel_id: str, **kwargs
-    ) -> Union[Future, SlackResponse]:
-        """Delete a public or private channel.
-
-        Args:
-            channel_id (str): The channel to delete.
-
-        """
-        kwargs.update({"channel_id": channel_id})
-        return self.api_call("admin.conversations.delete", json=kwargs)
-
-    def admin_conversations_invite(
-        self, *, channel_id: str, user_ids: Union[str, List[str]], **kwargs
-    ) -> Union[Future, SlackResponse]:
-        """Invite a user to a public or private channel.
-
-        Args:
-            channel_id (str): The channel that the users will be invited to.
-            user_ids (str or list): The users to invite.
-        """
-        kwargs.update({"channel_id": channel_id})
-        if isinstance(user_ids, list):
-            kwargs.update({"user_ids": ",".join(user_ids)})
-        else:
-            kwargs.update({"user_ids": user_ids})
-        # NOTE: the endpoint is unable to handle Content-Type: application/json as of Sep 3, 2020.
-        return self.api_call("admin.conversations.invite", params=kwargs)
-
-    def admin_conversations_archive(
-        self, *, channel_id: str, **kwargs
-    ) -> Union[Future, SlackResponse]:
-        """Archive a public or private channel.
-
-        Args:
-            channel_id (str): The channel to archive.
-        """
-        kwargs.update({"channel_id": channel_id})
-        return self.api_call("admin.conversations.archive", json=kwargs)
-
-    def admin_conversations_unarchive(
-        self, *, channel_id: str, **kwargs
-    ) -> Union[Future, SlackResponse]:
-        """Unarchive a public or private channel.
-
-        Args:
-            channel_id (str): The channel to unarchive.
-        """
-        kwargs.update({"channel_id": channel_id})
-        return self.api_call("admin.conversations.unarchive", json=kwargs)
-
-    def admin_conversations_rename(
-        self, *, channel_id: str, name: str, **kwargs
-    ) -> Union[Future, SlackResponse]:
-        """Rename a public or private channel.
-
-        Args:
-            channel_id (str): The channel to rename.
-            name (str): The name to rename the channel to.
-        """
-        kwargs.update({"channel_id": channel_id, "name": name})
-        return self.api_call("admin.conversations.rename", json=kwargs)
-
-    def admin_conversations_search(self, **kwargs) -> Union[Future, SlackResponse]:
-        """Search for public or private channels in an Enterprise organization."""
-        return self.api_call("admin.conversations.search", json=kwargs)
-
-    def admin_conversations_convertToPrivate(
-        self, *, channel_id: str, **kwargs
-    ) -> Union[Future, SlackResponse]:
-        """Convert a public channel to a private channel.
-
-        Args:
-            channel_id (str): The channel to convert to private.
-        """
-        kwargs.update({"channel_id": channel_id})
-        return self.api_call("admin.conversations.convertToPrivate", json=kwargs)
-
-    def admin_conversations_setConversationPrefs(
-        self, *, channel_id: str, prefs: Union[str, dict], **kwargs
-    ) -> Union[Future, SlackResponse]:
-        """Set the posting permissions for a public or private channel.
-
-        Args:
-            channel_id (str): The channel to set the prefs for
-            prefs (str or dict): The prefs for this channel in a stringified JSON format.
-        """
-        kwargs.update({"channel_id": channel_id, "prefs": prefs})
-        return self.api_call("admin.conversations.setConversationPrefs", json=kwargs)
-
-    def admin_conversations_getConversationPrefs(
-        self, *, channel_id: str, **kwargs
-    ) -> Union[Future, SlackResponse]:
-        """Get conversation preferences for a public or private channel.
-
-        Args:
-            channel_id (str): The channel to get the preferences for.
-        """
-        kwargs.update({"channel_id": channel_id})
-        return self.api_call("admin.conversations.getConversationPrefs", json=kwargs)
-
-    def admin_conversations_disconnectShared(
-        self, *, channel_id: str, **kwargs
-    ) -> Union[Future, SlackResponse]:
-        """Disconnect a connected channel from one or more workspaces.
-
-        Args:
-            channel_id (str): The channel to be disconnected from some workspaces.
-        """
-        kwargs.update({"channel_id": channel_id})
-        return self.api_call("admin.conversations.disconnectShared", json=kwargs)
-
-    def admin_conversations_ekm_listOriginalConnectedChannelInfo(
-        self, **kwargs
-    ) -> Union[Future, SlackResponse]:
-        """List all disconnected channels—i.e.,
-        channels that were once connected to other workspaces and then disconnected—and
-        the corresponding original channel IDs for key revocation with EKM.
-        """
-        return self.api_call(
-            "admin.conversations.ekm.listOriginalConnectedChannelInfo", params=kwargs
-        )


### PR DESCRIPTION
## Summary

This pull request applies two minor improvements in addition to #795 

* Move the added methods at the bottom to the right position (it's okay not to be strictly in alphabetical order, though)
* Add more conditions/assertions to search tests

### Category (place an `x` in each of the `[ ]`)

- [x] **slack.web.WebClient** (Web API client)
- [ ] **slack.webhook.WebhookClient** (Incoming Webhook, response_url sender)
- [ ] **slack.web.classes** (UI component builders)
- [ ] **slack.rtm.RTMClient** (RTM client)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes.
