### PR TITLE
Add support for Workflow Steps from Apps

### DIFF
--- a/slack/web/classes/views.py
+++ b/slack/web/classes/views.py
@@ -13,7 +13,7 @@ class View(JsonObject):
     https://api.slack.com/reference/surfaces/views
     """
 
-    types = ["modal", "home"]
+    types = ["modal", "home", "workflow_step"]
 
     attributes = {
         "type",
@@ -38,7 +38,7 @@ class View(JsonObject):
 
     def __init__(
         self,
-        # type's possible values are "modal", "home"
+        # type's possible values are "modal", "home" and "workflow_step"
         type: str,  # skipcq: PYL-W0622
         id: Optional[str] = None,  # skipcq: PYL-W0622
         callback_id: Optional[str] = None,
@@ -88,7 +88,7 @@ class View(JsonObject):
     private_metadata_max_length = 3000
     callback_id_max_length: int = 255
 
-    @JsonValidator('type must be either "modal" or "home"')
+    @JsonValidator('type must be either "modal", "home" or "workflow_step"')
     def _validate_type(self):
         return self.type is not None and self.type in self.types
 

--- a/slack/web/client.py
+++ b/slack/web/client.py
@@ -2154,3 +2154,66 @@ class WebClient(BaseClient):
         else:
             kwargs.update({"view": view})
         return self.api_call("views.publish", json=kwargs)
+
+    def workflows_stepCompleted(
+        self,
+        *,
+        workflow_step_execute_id: str,
+        outputs: dict = {},
+        **kwargs
+    ) -> Union[Future, SlackResponse]:
+        """Indicate a successful outcome of a workflow step's execution.
+        Args:
+            workflow_step_execute_id (str): A unique identifier of the workflow step to be updated.
+                e.g. 'add_task'
+            outputs (dict): A key-value object of outputs from your step.
+                e.g. { 'task_name': 'Task Name' }
+        """
+        kwargs.update({"workflow_step_execute_id": workflow_step_execute_id})
+        if outputs:
+            kwargs.update({"outputs": outputs})
+
+        return self.api_call("workflows.stepCompleted", json=kwargs)
+
+    def workflows_stepFailed(
+        self,
+        *,
+        workflow_step_execute_id: str,
+        error: dict,
+        **kwargs
+    ) -> Union[Future, SlackResponse]:
+        """Indicate an unsuccessful outcome of a workflow step's execution.
+        Args:
+            workflow_step_execute_id (str): A unique identifier of the workflow step to be updated.
+                e.g. 'add_task'
+            error (dict): A dict with a message property that contains a human readable error message
+                e.g. { message: 'Step failed to execute.' }
+        """
+        kwargs.update({"workflow_step_execute_id": workflow_step_execute_id, "error": error})
+        return self.api_call("workflows.stepFailed", json=kwargs)
+
+    def workflows_updateStep(
+        self,
+        *,
+        workflow_step_edit_id: str,
+        inputs: dict = {},
+        outputs: list = [],
+        **kwargs
+    ) -> Union[Future, SlackResponse]:
+        """Indicate an unsuccessful outcome of a workflow step's execution.
+        Args:
+            workflow_step_edit_id (str): A unique identifier of the workflow step to be updated.
+                e.g. 'add_task'
+            inputs (dict): A key-value object of inputs required from a user during step configuration.
+                e.g. { 'title': { 'value': 'The Title' }, 'submitter': { 'value': 'The Submitter' } }
+            outputs (list): A list of output objects used during step execution.
+                e.g. [{ 'type': 'text', 'name': 'title', 'label': 'Title' }]
+        """
+        kwargs.update({"workflow_step_edit_id": workflow_step_edit_id})
+
+        if inputs:
+            kwargs.update({"inputs": inputs})
+        if outputs:
+            kwargs.update({"outputs": outputs})
+
+        return self.api_call("workflows.updateStep", json=kwargs)

--- a/slack/web/client.py
+++ b/slack/web/client.py
@@ -2159,7 +2159,7 @@ class WebClient(BaseClient):
         self,
         *,
         workflow_step_execute_id: str,
-        outputs: dict = {},
+        outputs: dict = None,
         **kwargs
     ) -> Union[Future, SlackResponse]:
         """Indicate a successful outcome of a workflow step's execution.
@@ -2196,11 +2196,11 @@ class WebClient(BaseClient):
         self,
         *,
         workflow_step_edit_id: str,
-        inputs: dict = {},
-        outputs: list = [],
+        inputs: dict = None,
+        outputs: list = None,
         **kwargs
     ) -> Union[Future, SlackResponse]:
-        """Indicate an unsuccessful outcome of a workflow step's execution.
+        """Update the configuration for a workflow extension step.
         Args:
             workflow_step_edit_id (str): A unique identifier of the workflow step to be updated.
                 e.g. 'add_task'

--- a/tests/web/test_web_client_coverage.py
+++ b/tests/web/test_web_client_coverage.py
@@ -504,6 +504,15 @@ class TestWebClientCoverage(unittest.TestCase):
                 elif method_name == "views_update":
                     self.api_methods_to_call.remove(method(view_id="V123", view={})["method"])
                     await async_method(view_id="V123", view={})
+                elif method_name == "workflows_stepCompleted":
+                    self.api_methods_to_call.remove(method(workflow_step_execute_id="S123", outputs={})["method"])
+                    await async_method(workflow_step_execute_id="S123", outputs={})
+                elif method_name == "workflows_stepFailed":
+                    self.api_methods_to_call.remove(method(workflow_step_execute_id="S456", error={})["method"])
+                    await async_method(workflow_step_execute_id="S456", error={})
+                elif method_name == "workflows_updateStep":
+                    self.api_methods_to_call.remove(method(workflow_step_edit_id="S789", inputs={}, outputs=[])["method"])
+                    await async_method(workflow_step_edit_id="S789", inputs={}, outputs=[])
                 elif method_name == "channels_archive":
                     self.api_methods_to_call.remove(method(channel="C123")["method"])
                     await async_method(channel="C123")


### PR DESCRIPTION
###  Summary

**‹‹ STATUS: IN PROGRESS -- DRAFT ››**

This pull request introduces support for [Workflow Steps from Apps](https://api.slack.com/workflows/steps).

---

> Workflow Steps provide the ability for Slack apps to create and process custom Workflow Steps for use in Workflows. Steps can be built to do things such as send data to external services, create tasks in project management systems, or update tickets. These steps can then be shared and used by anyone in the Workflow Builder to incorporate into Workflows they're building.
> 
> For more information on Workflow Steps, read full details here: https://api.slack.com/workflows/steps

### Category (place an `x` in each of the `[ ]`)

- [x] **slack.web.WebClient** (Web API client)
- [ ] **slack.webhook.WebhookClient** (Incoming Webhook, response_url sender)
- [x] **slack.web.classes** (UI component builders)
- [ ] **slack.rtm.RTMClient** (RTM client)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [ ] I've run `python setup.py validate` after making the changes.
