### PR TITLE
Only set default filename in files_upload if file is an instance of str

### DIFF
--- a/slack/web/async_client.py
+++ b/slack/web/async_client.py
@@ -1501,7 +1501,7 @@ class AsyncWebClient(AsyncBaseClient):
             )
 
         if file:
-            if "filename" not in kwargs:
+            if "filename" not in kwargs and isinstance(file, str):
                 # use the local filename if filename is missing
                 kwargs["filename"] = file.split(os.path.sep)[-1]
             return await self.api_call(

--- a/slack/web/client.py
+++ b/slack/web/client.py
@@ -1491,7 +1491,7 @@ class WebClient(BaseClient):
             )
 
         if file:
-            if "filename" not in kwargs:
+            if "filename" not in kwargs and isinstance(file, str):
                 # use the local filename if filename is missing
                 kwargs["filename"] = file.split(os.path.sep)[-1]
             return self.api_call("files.upload", files={"file": file}, data=kwargs)


### PR DESCRIPTION
## Summary
Fixes #809

3ef65f39461855394fd02de20f55aca5f14b6b88 changed [files_upload](https://github.com/slackapi/python-slackclient/blob/033fb44f64d5c5f5664a8b6752adf3e4beba7854/slack/web/client.py#L1473) behavior to always set default filename regardless of instace type of file input parameter. If file is of type IOBase, which the type hinting indicates is supported, [#L1496](https://github.com/slackapi/python-slackclient/blob/033fb44f64d5c5f5664a8b6752adf3e4beba7854/slack/web/client.py#L1496) would raise an exception when trying to call `split` on a non-string type. Since the Slack API files_upload does not require a filename to upload, I do not believe this method should either.

No unit tests added as this code change should still be coverd by https://github.com/slackapi/python-slackclient/blob/033fb44f64d5c5f5664a8b6752adf3e4beba7854/integration_tests/web/test_issue_672.py#L65

I can add a test for `file` being an `IOBase` instance.
### Category (place an `x` in each of the `[ ]`)

- [x ] **slack.web.WebClient** (Web API client)
- [ ] **slack.webhook.WebhookClient** (Incoming Webhook, response_url sender)
- [ ] **slack.web.classes** (UI component builders)
- [ ] **slack.rtm.RTMClient** (RTM client)

## Requirements (place an `x` in each `[ ]`)

- [x ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x ] I've run `python setup.py validate` after making the changes.
