### PR TITLE
Fix or skip DeepSource warnings

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,8 @@
 [run]
 branch = True
-source = slack
+source =
+    slack_sdk/**
+    slack/**
 
 [report]
 exclude_lines =

--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -13,6 +13,9 @@ exclude_patterns = [
   "docs/**",
   "docs-src/**",
   "tutorial/**",
+  "slack/**",
+  "slack_sdk/web/async_client.py",
+  "slack_sdk/web/legacy_client.py",
   "tests/**",
   "integration_tests/**"
 ]

--- a/slack_sdk/errors/__init__.py
+++ b/slack_sdk/errors/__init__.py
@@ -9,8 +9,7 @@ class BotUserAccessError(SlackClientError):
 
 
 class SlackRequestError(SlackClientError):
-    """Error raised when there's a problem with the request that's being submitted.
-    """
+    """Error raised when there's a problem with the request that's being submitted."""
 
 
 class SlackApiError(SlackClientError):

--- a/slack_sdk/models/attachments/__init__.py
+++ b/slack_sdk/models/attachments/__init__.py
@@ -42,7 +42,7 @@ class Action(JsonObject):
     def name_or_url_present(self):
         return self.name is not None or self.url is not None
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict:  # skipcq: PYL-W0221
         json = super().to_dict()
         json["type"] = self.subtype
         return json
@@ -423,7 +423,7 @@ class Attachment(JsonObject):
     def author_link_without_author_icon(self):
         return self.author_link is None or self.author_icon is not None
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict:  # skipcq: PYL-W0221
         json = super().to_dict()
         if self.fields is not None:
             json["fields"] = extract_json(self.fields)

--- a/slack_sdk/models/basic_objects.py
+++ b/slack_sdk/models/basic_objects.py
@@ -36,11 +36,11 @@ class JsonObject(BaseObject, metaclass=ABCMeta):
         def to_dict_compatible(
             value: Union[dict, list, object]
         ) -> Union[dict, list, Any]:
-            if isinstance(value, list):
+            if isinstance(value, list):  # skipcq: PYL-R1705
                 return [to_dict_compatible(v) for v in value]
             else:
                 to_dict = getattr(value, "to_dict", None)
-                if to_dict and callable(to_dict):
+                if to_dict and callable(to_dict):  # skipcq: PYL-R1705
                     return {
                         k: to_dict_compatible(v) for k, v in value.to_dict().items()  # type: ignore
                     }
@@ -52,7 +52,7 @@ class JsonObject(BaseObject, metaclass=ABCMeta):
             if value is None:
                 return False
             has_len = getattr(value, "__len__", None) is not None
-            if has_len:
+            if has_len:  # skipcq: PYL-R1705
                 return len(value) > 0
             else:
                 return value is not None
@@ -78,7 +78,7 @@ class JsonObject(BaseObject, metaclass=ABCMeta):
 
     def __repr__(self):
         dict_value = self.get_non_null_attributes()
-        if dict_value:
+        if dict_value:  # skipcq: PYL-R1705
             return f"<slack_sdk.{self.__class__.__name__}: {dict_value}>"
         else:
             return self.__str__()

--- a/slack_sdk/models/blocks/__init__.py
+++ b/slack_sdk/models/blocks/__init__.py
@@ -9,8 +9,6 @@ from .basic_components import TextObject  # noqa
 from .block_elements import BlockElement  # noqa
 from .block_elements import ButtonElement  # noqa
 from .block_elements import ChannelMultiSelectElement  # noqa
-from .block_elements import ChannelMultiSelectElement  # noqa
-from .block_elements import ChannelMultiSelectElement  # noqa
 from .block_elements import ChannelSelectElement  # noqa
 from .block_elements import CheckboxesElement  # noqa
 from .block_elements import ConversationFilter  # noqa

--- a/slack_sdk/models/blocks/basic_components.py
+++ b/slack_sdk/models/blocks/basic_components.py
@@ -18,7 +18,7 @@ class TextObject(JsonObject):
     attributes = {"text", "type", "emoji"}
     logger = logging.getLogger(__name__)
 
-    def _subtype_warning(self):
+    def _subtype_warning(self):  # skipcq: PYL-R0201
         warnings.warn(
             "subtype is deprecated since slackclient 2.6.0, use type instead",
             DeprecationWarning,
@@ -32,17 +32,17 @@ class TextObject(JsonObject):
     def parse(
         cls, text: Union[str, dict, "TextObject"], default_type: str = "mrkdwn"
     ) -> Optional["TextObject"]:
-        if not text:
+        if not text:  # skipcq: PYL-R1705
             return None
         elif isinstance(text, str):
-            if default_type == PlainTextObject.type:
+            if default_type == PlainTextObject.type:  # skipcq: PYL-R1705
                 return PlainTextObject.from_str(text)
             else:
                 return MarkdownTextObject.from_str(text)
         elif isinstance(text, dict):
             d = copy.copy(text)
             t = d.pop("type")
-            if t == PlainTextObject.type:
+            if t == PlainTextObject.type:  # skipcq: PYL-R1705
                 return PlainTextObject(**d)
             else:
                 return MarkdownTextObject(**d)
@@ -57,14 +57,12 @@ class TextObject(JsonObject):
     def __init__(
         self,
         text: str,
-        type: Optional[str] = None,
+        type: Optional[str] = None,  # skipcq: PYL-W0622
         subtype: Optional[str] = None,
         emoji: Optional[bool] = None,
         **kwargs,
     ):
-        """
-        Super class for new text "objects" used in Block kit
-        """
+        """Super class for new text "objects" used in Block kit"""
         if subtype:
             self._subtype_warning()
 
@@ -94,9 +92,7 @@ class PlainTextObject(TextObject):
 
     @staticmethod
     def direct_from_string(text: str) -> dict:
-        """
-        Transforms a string into the required object shape to act as a PlainTextObject
-        """
+        """Transforms a string into the required object shape to act as a PlainTextObject"""
         return PlainTextObject.from_str(text).to_dict()
 
 
@@ -117,19 +113,19 @@ class MarkdownTextObject(TextObject):
 
     @staticmethod
     def from_str(text: str) -> "MarkdownTextObject":
-        """Transforms a string into the required object shape to act as a MarkdownTextObject
-        """
+        """Transforms a string into the required object shape to act as a MarkdownTextObject"""
         return MarkdownTextObject(text=text)
 
     @staticmethod
     def direct_from_string(text: str) -> dict:
-        """Transforms a string into the required object shape to act as a MarkdownTextObject
-        """
+        """Transforms a string into the required object shape to act as a MarkdownTextObject"""
         return MarkdownTextObject.from_str(text).to_dict()
 
     @staticmethod
     def from_link(link: Link, title: str = "") -> "MarkdownTextObject":
-        """Transform a Link object directly into the required object shape to act as a MarkdownTextObject
+        """
+        Transform a Link object directly into the required object shape
+        to act as a MarkdownTextObject
         """
         if title:
             title = f": {title}"
@@ -137,7 +133,9 @@ class MarkdownTextObject(TextObject):
 
     @staticmethod
     def direct_from_link(link: Link, title: str = "") -> dict:
-        """Transform a Link object directly into the required object shape to act as a MarkdownTextObject
+        """
+        Transform a Link object directly into the required object shape
+        to act as a MarkdownTextObject
         """
         return MarkdownTextObject.from_link(link, title).to_dict()
 
@@ -242,14 +240,14 @@ class Option(JsonObject):
                 cls.logger.warning(f"Unknown option object detected and skipped ({o})")
         return option_objects
 
-    def to_dict(self, option_type: str = "block") -> dict:
+    def to_dict(self, option_type: str = "block") -> dict:  # skipcq: PYL-W0221
         """
         Different parent classes must call this with a valid value from OptionTypes -
         either "dialog", "action", or "block", so that JSON is returned in the
         correct shape.
         """
         self.validate_json()
-        if option_type == "dialog":
+        if option_type == "dialog":  # skipcq: PYL-R1705
             return {"label": self.label, "value": self.value}
         elif option_type == "action":
             json = {"text": self.label, "value": self.value}
@@ -270,9 +268,7 @@ class Option(JsonObject):
 
     @staticmethod
     def from_single_value(value_and_label: str):
-        """
-        Creates a simple Option instance with the same value and label
-        """
+        """Creates a simple Option instance with the same value and label"""
         return Option(value=value_and_label, label=value_and_label)
 
 
@@ -346,10 +342,10 @@ class OptionGroup(JsonObject):
                 )
         return option_group_objects
 
-    def to_dict(self, option_type: str = "block") -> dict:
+    def to_dict(self, option_type: str = "block") -> dict:  # skipcq: PYL-W0221
         self.validate_json()
         dict_options = [o.to_dict(option_type) for o in self.options]
-        if option_type == "dialog":
+        if option_type == "dialog":  # skipcq: PYL-R1705
             return {
                 "label": self.label,
                 "options": dict_options,
@@ -378,13 +374,14 @@ class ConfirmObject(JsonObject):
     @classmethod
     def parse(cls, confirm: Union["ConfirmObject", dict]):
         if confirm:
-            if isinstance(confirm, ConfirmObject):
+            if isinstance(confirm, ConfirmObject):  # skipcq: PYL-R1705
                 return confirm
             elif isinstance(confirm, dict):
                 return ConfirmObject(**confirm)
             else:
-                # TODO: warning
+                # Not yet implemented: show some warning here
                 return None
+        return None
 
     def __init__(
         self,
@@ -436,8 +433,8 @@ class ConfirmObject(JsonObject):
     def _validate_confirm_style(self):
         return self._style is None or self._style in ["primary", "danger"]
 
-    def to_dict(self, option_type: str = "block") -> dict:
-        if option_type == "action":
+    def to_dict(self, option_type: str = "block") -> dict:  # skipcq: PYL-W0221
+        if option_type == "action":  # skipcq: PYL-R1705
             # deliberately skipping JSON validators here - can't find documentation
             # on actual limits here
             json = {

--- a/slack_sdk/models/blocks/block_elements.py
+++ b/slack_sdk/models/blocks/block_elements.py
@@ -33,7 +33,7 @@ class BlockElement(JsonObject, metaclass=ABCMeta):
     attributes = {"type"}
     logger = logging.getLogger(__name__)
 
-    def _subtype_warning(self):
+    def _subtype_warning(self):  # skipcq: PYL-R0201
         warnings.warn(
             "subtype is deprecated since slackclient 2.6.0, use type instead",
             DeprecationWarning,
@@ -46,7 +46,7 @@ class BlockElement(JsonObject, metaclass=ABCMeta):
     def __init__(
         self,
         *,
-        type: Optional[str] = None,
+        type: Optional[str] = None,  # skipcq: PYL-W0622
         subtype: Optional[str] = None,
         **others: dict,
     ):
@@ -59,13 +59,13 @@ class BlockElement(JsonObject, metaclass=ABCMeta):
     def parse(
         cls, block_element: Union[dict, "BlockElement"]
     ) -> Optional[Union["BlockElement", TextObject]]:
-        if block_element is None:
+        if block_element is None:  # skipcq: PYL-R1705
             return None
         elif isinstance(block_element, dict):
             if "type" in block_element:
                 d = copy.copy(block_element)
                 t = d.pop("type")
-                if t == PlainTextObject.type:
+                if t == PlainTextObject.type:  # skipcq: PYL-R1705
                     return PlainTextObject(**d)
                 elif t == MarkdownTextObject.type:
                     return MarkdownTextObject(**d)
@@ -144,7 +144,7 @@ class InteractiveElement(BlockElement):
         self,
         *,
         action_id: Optional[str] = None,
-        type: Optional[str] = None,
+        type: Optional[str] = None,  # skipcq: PYL-W0622
         subtype: Optional[str] = None,
         **others: dict,
     ):
@@ -184,7 +184,7 @@ class InputInteractiveElement(InteractiveElement, metaclass=ABCMeta):
         *,
         action_id: Optional[str] = None,
         placeholder: Union[str, TextObject] = None,
-        type: Optional[str] = None,
+        type: Optional[str] = None,  # skipcq: PYL-W0622
         subtype: Optional[str] = None,
         confirm: Optional[Union[dict, ConfirmObject]] = None,
         **others: dict,
@@ -768,8 +768,8 @@ class ConversationFilter(JsonObject):
         self.exclude_bot_users = exclude_bot_users
 
     @classmethod
-    def parse(cls, filter: Union[dict, "ConversationFilter"]):
-        if filter is None:
+    def parse(cls, filter: Union[dict, "ConversationFilter"]):  # skipcq: PYL-W0622
+        if filter is None:  # skipcq: PYL-R1705
             return None
         elif isinstance(filter, ConversationFilter):
             return filter
@@ -806,7 +806,7 @@ class ConversationSelectElement(InputInteractiveElement):
         confirm: Optional[Union[dict, ConfirmObject]] = None,
         response_url_enabled: Optional[bool] = None,
         default_to_current_conversation: Optional[bool] = None,
-        filter: Optional[ConversationFilter] = None,
+        filter: Optional[ConversationFilter] = None,  # skipcq: PYL-W0622
         **others: dict,
     ):
         """
@@ -851,7 +851,7 @@ class ConversationMultiSelectElement(InputInteractiveElement):
         confirm: Optional[Union[dict, ConfirmObject]] = None,
         max_selected_items: Optional[int] = None,
         default_to_current_conversation: Optional[bool] = None,
-        filter: Optional[Union[dict, ConversationFilter]] = None,
+        filter: Optional[Union[dict, ConversationFilter]] = None,  # skipcq: PYL-W0622
         **others: dict,
     ):
         """
@@ -1066,7 +1066,7 @@ class OverflowMenuElement(InteractiveElement):
         super().__init__(action_id=action_id, type=self.type)
         show_unknown_key_warning(self, others)
 
-        self.options = options  # TODO
+        self.options = options
         self.confirm = ConfirmObject.parse(confirm)
 
     @JsonValidator(

--- a/slack_sdk/models/blocks/blocks.py
+++ b/slack_sdk/models/blocks/blocks.py
@@ -31,7 +31,7 @@ class Block(JsonObject):
     block_id_max_length = 255
     logger = logging.getLogger(__name__)
 
-    def _subtype_warning(self):
+    def _subtype_warning(self):  # skipcq: PYL-R0201
         warnings.warn(
             "subtype is deprecated since slackclient 2.6.0, use type instead",
             DeprecationWarning,
@@ -44,7 +44,7 @@ class Block(JsonObject):
     def __init__(
         self,
         *,
-        type: Optional[str] = None,
+        type: Optional[str] = None,  # skipcq: PYL-W0622
         subtype: Optional[str] = None,  # deprecated
         block_id: Optional[str] = None,
     ):
@@ -60,14 +60,14 @@ class Block(JsonObject):
 
     @classmethod
     def parse(cls, block: Union[dict, "Block"]) -> Optional["Block"]:
-        if block is None:
+        if block is None:  # skipcq: PYL-R1705
             return None
         elif isinstance(block, Block):
             return block
         else:
             if "type" in block:
-                type = block["type"]
-                if type == SectionBlock.type:
+                type = block["type"]  # skipcq: PYL-W0622
+                if type == SectionBlock.type:  # skipcq: PYL-R1705
                     return SectionBlock(**block)
                 elif type == DividerBlock.type:
                     return DividerBlock(**block)
@@ -93,7 +93,7 @@ class Block(JsonObject):
                 return None
 
     @classmethod
-    def parse_all(cls, blocks: List[Union[dict, "Block"]]) -> List["Block"]:
+    def parse_all(cls, blocks: Optional[List[Union[dict, "Block"]]]) -> List["Block"]:
         return [cls.parse(b) for b in blocks or []]
 
 

--- a/slack_sdk/models/dialoags/__init__.py
+++ b/slack_sdk/models/dialoags/__init__.py
@@ -188,7 +188,7 @@ class AbstractDialogSelector(JsonObject, metaclass=ABCMeta):
     def data_source_valid(self):
         return self.data_source in self.DataSourceTypes
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict:  # skipcq: PYL-W0221
         json = super().to_dict()
         if self.data_source == "external":
             if isinstance(self.value, Option):
@@ -272,7 +272,7 @@ class DialogStaticSelector(AbstractDialogSelector):
 class DialogUserSelector(AbstractDialogSelector):
     data_source = "users"
 
-    def __init__(
+    def __init__(  # skipcq: PYL-W0235
         self,
         *,
         name: str,
@@ -310,7 +310,7 @@ class DialogUserSelector(AbstractDialogSelector):
 class DialogChannelSelector(AbstractDialogSelector):
     data_source = "channels"
 
-    def __init__(
+    def __init__(  # skipcq: PYL-W0235
         self,
         *,
         name: str,
@@ -346,7 +346,7 @@ class DialogChannelSelector(AbstractDialogSelector):
 class DialogConversationSelector(AbstractDialogSelector):
     data_source = "conversations"
 
-    def __init__(
+    def __init__(  # skipcq: PYL-W0235
         self,
         *,
         name: str,
@@ -850,7 +850,7 @@ class DialogBuilder(JsonObject):
     def state_length(self):
         return not self._state or len(self._state) <= self.state_max_length
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict:  # skipcq: PYL-W0221
         self.validate_json()
         json = {
             "title": self._title,

--- a/slack_sdk/models/messages/message.py
+++ b/slack_sdk/models/messages/message.py
@@ -55,7 +55,7 @@ class Message(JsonObject):
             or len(self.attachments) <= self.attachments_max_length
         )
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict:  # skipcq: PYL-W0221
         json = super().to_dict()
         if len(self.text) > 40000:
             LOGGER.error(

--- a/slack_sdk/models/views/__init__.py
+++ b/slack_sdk/models/views/__init__.py
@@ -37,8 +37,9 @@ class View(JsonObject):
 
     def __init__(
         self,
-        type: str,  # "modal", "home", and "workflow_step"
-        id: Optional[str] = None,
+        # "modal", "home", and "workflow_step"
+        type: str,  # skipcq: PYL-W0622
+        id: Optional[str] = None,  # skipcq: PYL-W0622
         callback_id: Optional[str] = None,
         external_id: Optional[str] = None,
         team_id: Optional[str] = None,
@@ -49,10 +50,10 @@ class View(JsonObject):
         title: Union[str, dict, PlainTextObject] = None,
         submit: Optional[Union[str, dict, PlainTextObject]] = None,
         close: Optional[Union[str, dict, PlainTextObject]] = None,
-        blocks: List[Union[dict, Block]] = [],
+        blocks: Optional[List[Union[dict, Block]]] = None,
         private_metadata: Optional[str] = None,
         state: Optional[Union[dict, "ViewState"]] = None,
-        hash: Optional[str] = None,
+        hash: Optional[str] = None,  # skipcq: PYL-W0622
         clear_on_close: Optional[bool] = None,
         notify_on_close: Optional[bool] = None,
         **kwargs,
@@ -147,10 +148,10 @@ class ViewState(JsonObject):
     logger = logging.getLogger(__name__)
 
     @classmethod
-    def _show_warning_about_unknown(self, value):
+    def _show_warning_about_unknown(cls, value):
         c = value.__class__
         name = ".".join([c.__module__, c.__name__])
-        self.logger.warning(
+        cls.logger.warning(
             f"Unknown type for view.state.values detected ({name}) and ViewState skipped to add it"
         )
 
@@ -160,7 +161,7 @@ class ViewState(JsonObject):
         value_objects: Dict[str, Dict[str, ViewStateValue]] = {}
         new_state_values = copy.copy(values)
         for block_id, actions in new_state_values.items():
-            if actions is None:
+            if actions is None:  # skipcq: PYL-R1724
                 continue
             elif isinstance(actions, dict):
                 new_actions = copy.copy(actions)
@@ -181,7 +182,7 @@ class ViewState(JsonObject):
 
     def to_dict(self, *args) -> Dict[str, Dict[str, Dict[str, dict]]]:  # type: ignore
         self.validate_json()
-        if self.values:
+        if self.values:  # skipcq: PYL-R1705
             dict_values: Dict[str, Dict[str, dict]] = {}
             for block_id, actions in self.values.items():
                 if actions:
@@ -213,7 +214,7 @@ class ViewStateValue(JsonObject):
     def __init__(
         self,
         *,
-        type: Optional[str] = None,
+        type: Optional[str] = None,  # skipcq: PYL-W0622
         value: Optional[str] = None,
         selected_date: Optional[str] = None,
         selected_conversation: Optional[str] = None,

--- a/slack_sdk/rtm/__init__.py
+++ b/slack_sdk/rtm/__init__.py
@@ -19,7 +19,7 @@ import slack_sdk.errors as client_err
 from slack_sdk.web.legacy_client import LegacyWebClient as WebClient
 
 
-class RTMClient(object):
+class RTMClient(object):  # skipcq: PYL-R0205
     """An RTMClient allows apps to communicate with the Slack Platform's RTM API.
 
     The event-driven architecture of this client allows you to simply
@@ -193,7 +193,7 @@ class RTMClient(object):
         Raises:
             SlackApiError: Unable to retrieve RTM URL from Slack.
         """
-        # TODO: Add Windows support for graceful shutdowns.
+        # Not yet implemented: Add Windows support for graceful shutdowns.
         if os.name != "nt" and current_thread() == main_thread():
             signals = (signal.SIGHUP, signal.SIGTERM, signal.SIGINT)
             for s in signals:
@@ -373,7 +373,7 @@ class RTMClient(object):
             except (
                 client_err.SlackClientNotConnectedError,
                 client_err.SlackApiError,
-                # TODO: Catch websocket exceptions thrown by aiohttp.
+                # Not yet implemented: Catch websocket exceptions thrown by aiohttp.
             ) as exception:
                 await self._dispatch_event(event="error", data=exception)
                 error_code = (
@@ -425,7 +425,7 @@ class RTMClient(object):
                     payload = message.json()
                     event = payload.pop("type", "Unknown")
                     await self._dispatch_event(event, data=payload)
-                except Exception as err:
+                except Exception as err:  # skipcq: PYL-W0703
                     data = message.data if message else message
                     self._logger.info(
                         f"Caught a raised exception ({err}) while dispatching a TEXT message ({data})"
@@ -578,7 +578,9 @@ class RTMClient(object):
         futures = []
         close_method = getattr(self._websocket, "close", None)
         if callable(close_method):
-            future = asyncio.ensure_future(close_method(), loop=self._event_loop)
+            future = asyncio.ensure_future(  # skipcq: PYL-E1102
+                close_method(), loop=self._event_loop  # skipcq: PYL-E1102
+            )  # skipcq: PYL-E1102
             futures.append(future)
         self._websocket = None
         event_f = asyncio.ensure_future(

--- a/slack_sdk/signature/__init__.py
+++ b/slack_sdk/signature/__init__.py
@@ -5,7 +5,7 @@ from typing import Dict, Optional, Union
 
 
 class Clock:
-    def now(self) -> float:
+    def now(self) -> float:  # skipcq: PYL-R0201
         return time()
 
 

--- a/slack_sdk/web/base_client.py
+++ b/slack_sdk/web/base_client.py
@@ -266,7 +266,7 @@ class BaseClient:
                 url = f"{url}&{q}" if "?" in url else f"{url}?{q}"
 
             response = self._perform_urllib_http_request(url=url, args=request_args)
-            if response.get("body", None):
+            if response.get("body", None):  # skipcq: PTC-W0039
                 try:
                     response_body_data: dict = json.loads(response["body"])
                 except json.decoder.JSONDecodeError as e:

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -705,7 +705,9 @@ class WebClient(BaseClient):
                 e.g. 'https://example.com/calls/1234567890'
         """
         kwargs.update({"external_unique_id": external_unique_id, "join_url": join_url})
-        _update_call_participants(kwargs, kwargs.get("users", None))
+        _update_call_participants(  # skipcq: PTC-W0039
+            kwargs, kwargs.get("users", None)  # skipcq: PTC-W0039
+        )  # skipcq: PTC-W0039
         return self.api_call("calls.add", http_verb="POST", params=kwargs)
 
     def calls_end(self, *, id: str, **kwargs) -> SlackResponse:  # skipcq: PYL-W0622

--- a/slack_sdk/web/legacy_base_client.py
+++ b/slack_sdk/web/legacy_base_client.py
@@ -346,7 +346,7 @@ class LegacyBaseClient:
                 url = f"{url}&{q}" if "?" in url else f"{url}?{q}"
 
             response = self._perform_urllib_http_request(url=url, args=request_args)
-            if response.get("body", None):
+            if response.get("body", None):  # skipcq: PTC-W0039
                 try:
                     response_body_data: dict = json.loads(response["body"])
                 except json.decoder.JSONDecodeError as e:

--- a/slack_sdk/web/legacy_slack_response.py
+++ b/slack_sdk/web/legacy_slack_response.py
@@ -9,7 +9,7 @@ import logging
 import slack_sdk.errors as e
 
 
-class LegacySlackResponse(object):
+class LegacySlackResponse(object):  # skipcq: PYL-R0205
     """An iterable container of response data.
 
     Attributes:
@@ -104,7 +104,7 @@ class LegacySlackResponse(object):
         Returns:
             (SlackResponse) self
         """
-        self._iteration = 0
+        self._iteration = 0  # skipcq: PYL-W0201
         self.data = self._initial_data
         return self
 
@@ -130,7 +130,7 @@ class LegacySlackResponse(object):
         self._iteration += 1
         if self._iteration == 1:
             return self
-        if self._next_cursor_is_present(self.data):
+        if self._next_cursor_is_present(self.data):  # skipcq: PYL-R1705
             params = self.req_args.get("params", {})
             if params is None:
                 params = {}
@@ -140,7 +140,7 @@ class LegacySlackResponse(object):
             if self._use_sync_aiohttp:
                 # We no longer recommend going with this way
                 response = asyncio.get_event_loop().run_until_complete(
-                    self._client._request(
+                    self._client._request(  # skipcq: PYL-W0212
                         http_verb=self.http_verb,
                         api_url=self.api_url,
                         req_args=self.req_args,
@@ -148,7 +148,7 @@ class LegacySlackResponse(object):
                 )
             else:
                 # This method sends a request in a synchronous way
-                response = self._client._request_for_pagination(
+                response = self._client._request_for_pagination(  # skipcq: PYL-W0212
                     api_url=self.api_url, req_args=self.req_args
                 )
 


### PR DESCRIPTION
## Summary

This pull request fixes (or skips) DeepSource warnings before adding more changes to the branch.

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack.web.WebClient** (Web API client)
- [ ] **slack.webhook.WebhookClient** (Incoming Webhook, response_url sender)
- [ ] **slack.web.classes** (UI component builders)
- [ ] **slack.rtm.RTMClient** (RTM client)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes.
