### PR TITLE
Fix proxy issue reported at #820 #821

### DIFF
--- a/slack/web/base_client.py
+++ b/slack/web/base_client.py
@@ -8,7 +8,7 @@ import io
 import json
 import logging
 import mimetypes
-import re
+import urllib
 import uuid
 import warnings
 from http.client import HTTPResponse
@@ -17,7 +17,7 @@ from typing import BinaryIO, Dict, List
 from typing import Optional, Union
 from urllib.error import HTTPError
 from urllib.parse import urlencode
-from urllib.request import Request, urlopen
+from urllib.request import Request, urlopen, OpenerDirector, ProxyHandler, HTTPSHandler
 
 import aiohttp
 from aiohttp import FormData, BasicAuth
@@ -455,20 +455,26 @@ class BaseClient:
             # (BAN-B310)
             if url.lower().startswith("http"):
                 req = Request(method="POST", url=url, data=body, headers=headers)
+                opener: Optional[OpenerDirector] = None
                 if self.proxy is not None:
                     if isinstance(self.proxy, str):
-                        host = re.sub("^https?://", "", self.proxy)
-                        req.set_proxy(host, "http")
-                        req.set_proxy(host, "https")
+                        opener = urllib.request.build_opener(
+                            ProxyHandler({"http": self.proxy, "https": self.proxy}),
+                            HTTPSHandler(context=self.ssl),
+                        )
                     else:
                         raise SlackRequestError(
                             f"Invalid proxy detected: {self.proxy} must be a str value"
                         )
 
                 # NOTE: BAN-B310 is already checked above
-                resp: HTTPResponse = urlopen(  # skipcq: BAN-B310
-                    req, context=self.ssl, timeout=self.timeout
-                )
+                resp: Optional[HTTPResponse] = None
+                if opener:
+                    resp = opener.open(req, timeout=self.timeout)  # skipcq: BAN-B310
+                else:
+                    resp = urlopen(  # skipcq: BAN-B310
+                        req, context=self.ssl, timeout=self.timeout
+                    )
                 charset = resp.headers.get_content_charset()
                 body: str = resp.read().decode(charset)  # read the response body here
                 return {"status": resp.code, "headers": resp.headers, "body": body}

--- a/slack/webhook/client.py
+++ b/slack/webhook/client.py
@@ -1,11 +1,11 @@
 import json
 import logging
-import re
+import urllib
 from http.client import HTTPResponse
 from ssl import SSLContext
 from typing import Dict, Union, List, Optional
 from urllib.error import HTTPError
-from urllib.request import Request, urlopen
+from urllib.request import Request, urlopen, OpenerDirector, ProxyHandler, HTTPSHandler
 
 from slack.errors import SlackRequestError
 from .internal_utils import _build_body, _build_request_headers, _debug_log_response
@@ -105,22 +105,33 @@ class WebhookClient:
             )
         try:
             url = self.url
+            opener: Optional[OpenerDirector] = None
             # for security (BAN-B310)
             if url.lower().startswith("http"):
                 req = Request(
                     method="POST", url=url, data=body.encode("utf-8"), headers=headers
                 )
                 if self.proxy is not None:
-                    host = re.sub("^https?://", "", self.proxy)
-                    req.set_proxy(host, "http")
-                    req.set_proxy(host, "https")
+                    if isinstance(self.proxy, str):
+                        opener = urllib.request.build_opener(
+                            ProxyHandler({"http": self.proxy, "https": self.proxy}),
+                            HTTPSHandler(context=self.ssl),
+                        )
+                    else:
+                        raise SlackRequestError(
+                            f"Invalid proxy detected: {self.proxy} must be a str value"
+                        )
             else:
                 raise SlackRequestError(f"Invalid URL detected: {url}")
 
             # NOTE: BAN-B310 is already checked above
-            resp: HTTPResponse = urlopen(  # skipcq: BAN-B310
-                req, context=self.ssl, timeout=self.timeout,
-            )
+            resp: Optional[HTTPResponse] = None
+            if opener:
+                resp = opener.open(req, timeout=self.timeout)  # skipcq: BAN-B310
+            else:
+                resp = urlopen(  # skipcq: BAN-B310
+                    req, context=self.ssl, timeout=self.timeout
+                )
             charset: str = resp.headers.get_content_charset() or "utf-8"
             response_body: str = resp.read().decode(charset)
             resp = WebhookResponse(


### PR DESCRIPTION
## Summary

As reported at #820 #821 , the current implementation of `WebClient`/`WebhookClient` when enabling `proxy` option started failing to send requests to the Slack API server. The implementation introduced by #715 has been working with the server-side for three months but it doesn't  work anymore. 

Other HTTP clients don't fail and the changes on the server-side look valid to me. I found that the implementation can be corrected in the way this PR does.

This issue is affecting some users in production. So, I will quickly release a new patch version after verifying the CI builds and running all the integration tests. 

Then, the affected users can deal with this issue by either of:
* Upgrade to the next patch version (2.9.1)
* Use `HTTPS_PROXY` environment variable over the `proxy` option in `WebClient` / `WebhookClient`

### Category (place an `x` in each of the `[ ]`)

- [x] **slack.web.WebClient** (Web API client)
- [x] **slack.webhook.WebhookClient** (Incoming Webhook, response_url sender)
- [ ] **slack.web.classes** (UI component builders)
- [ ] **slack.rtm.RTMClient** (RTM client)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes.
