### PR TITLE
Correct the text validation in header blocks

### DIFF
--- a/slack/web/classes/blocks.py
+++ b/slack/web/classes/blocks.py
@@ -387,7 +387,7 @@ class CallBlock(Block):
 
 class HeaderBlock(Block):
     type = "header"
-    text_max_length = 3000
+    text_max_length = 150
 
     @property
     def attributes(self) -> Set[str]:
@@ -411,3 +411,7 @@ class HeaderBlock(Block):
     @JsonValidator("text attribute must be specified")
     def _validate_text_populated(self):
         return self.text is not None
+
+    @JsonValidator(f"text attribute cannot exceed {text_max_length} characters")
+    def _validate_alt_text_length(self):
+        return self.text is None or len(self.text.text) <= self.text_max_length

--- a/tests/web/classes/test_blocks.py
+++ b/tests/web/classes/test_blocks.py
@@ -713,3 +713,21 @@ class HeaderBlockTests(unittest.TestCase):
         }
         self.assertDictEqual(input, HeaderBlock(**input).to_dict())
         self.assertDictEqual(input, Block.parse(input).to_dict())
+
+    def test_text_length_150(self):
+        input = {
+            "type": "header",
+            "block_id": "budget-header",
+            "text": {"type": "plain_text", "text": "1234567890" * 15},
+        }
+        HeaderBlock(**input).validate_json()
+
+    def test_text_length_151(self):
+        input = {
+            "type": "header",
+            "block_id": "budget-header",
+            "text": {"type": "plain_text", "text": ("1234567890" * 15) + "1"},
+        }
+        with self.assertRaises(SlackObjectFormationError):
+            HeaderBlock(**input).validate_json()
+


### PR DESCRIPTION
## Summary

`text` field validation in `header` blocks introduced by #768 has not been working. This pull request corrects the implementation to use the max length. 

In addition, this PR adjusts the upper limit. The max length in the document (3000) is incorrect (or outdated). The actual behavior is up to 150 characters. The API document team is going to update the page soon.

cc @mwbrooks (as the author of #768)

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack.web.WebClient** (Web API client)
- [ ] **slack.webhook.WebhookClient** (Incoming Webhook, response_url sender)
- [x] **slack.web.classes** (UI component builders)
- [ ] **slack.rtm.RTMClient** (RTM client)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes.
