### PR TITLE
[#830] Clarify channel type in v3 docs for Running the App

### DIFF
--- a/tutorial/04-running-the-app.md
+++ b/tutorial/04-running-the-app.md
@@ -45,7 +45,7 @@ When you click the green **Save Changes** button, you'll need to reinstall your 
 
 ### 🎉 That's it. Congratulations! You've just built a Slack app. 🤖
 
-To demo the app, simply send the bot a message that says "start". And then, the app will post a new message in the same channel. You can interact with the message by adding a reaction to it and adding the message to the pinned items. If the app is properly configured, you will see the modifications of the message accordingly.
+To demo the app, simply invite your bot to a public channel and send a message that says "start". And then, the app will post a new message in the same channel. You can interact with the message by adding a reaction to it and adding the message to the pinned items. If the app is properly configured, you will see the modifications of the message accordingly.
 
 ## ![Onboarding](https://user-images.githubusercontent.com/3329665/56870674-ab02b300-69c7-11e9-9101-eb823235f3c2.gif)
 


### PR DESCRIPTION
## Summary

In issue slackapi#830, a developer tried to DM the bot and didn't
receive a response because the 'message.im' event was not used.

This tutorial only uses 'message.channels', so the bot must be
invited to a public channel to receive the "start" message.

This commit clarifies that the bot must be invited to a public channel
for the `v3` docs.

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack.web.WebClient** (Web API client)
- [ ] **slack.webhook.WebhookClient** (Incoming Webhook, response_url sender)
- [ ] **slack.web.classes** (UI component builders)
- [ ] **slack.rtm.RTMClient** (RTM client)
- [x] Documents
- [ ] Others

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes.
