### PR TITLE
[v3] Add Dispatch Action in Block Kit #841

### DIFF
--- a/slack_sdk/models/blocks/basic_components.py
+++ b/slack_sdk/models/blocks/basic_components.py
@@ -465,3 +465,35 @@ class ConfirmObject(JsonObject):
             if self._style:
                 json["style"] = self._style
             return json
+
+
+class DispatchActionConfig(JsonObject):
+    attributes = {"trigger_actions_on"}
+
+    @classmethod
+    def parse(cls, config: Union["DispatchActionConfig", dict]):
+        if config:
+            if isinstance(config, DispatchActionConfig):  # skipcq: PYL-R1705
+                return config
+            elif isinstance(config, dict):
+                return DispatchActionConfig(**config)
+            else:
+                # Not yet implemented: show some warning here
+                return None
+        return None
+
+    def __init__(
+        self, *, trigger_actions_on: Optional[list] = None,
+    ):
+        """
+        Determines when a plain-text input element will return a block_actions interaction payload.
+        https://api.slack.com/reference/block-kit/composition-objects#dispatch_action_config
+        """
+        self._trigger_actions_on = trigger_actions_on or []
+
+    def to_dict(self) -> dict:  # skipcq: PYL-W0221
+        self.validate_json()
+        json = {}
+        if self._trigger_actions_on:
+            json["trigger_actions_on"] = self._trigger_actions_on
+        return json

--- a/slack_sdk/models/blocks/block_elements.py
+++ b/slack_sdk/models/blocks/block_elements.py
@@ -13,6 +13,7 @@ from slack_sdk.models.basic_objects import (
 )
 from .basic_components import ButtonStyles
 from .basic_components import ConfirmObject
+from .basic_components import DispatchActionConfig
 from .basic_components import MarkdownTextObject
 from .basic_components import Option
 from .basic_components import OptionGroup
@@ -957,7 +958,13 @@ class PlainTextInputElement(InputInteractiveElement):
     @property
     def attributes(self) -> Set[str]:
         return super().attributes.union(
-            {"initial_value", "multiline", "min_length", "max_length"}
+            {
+                "initial_value",
+                "multiline",
+                "min_length",
+                "max_length",
+                "dispatch_action_config",
+            }
         )
 
     def __init__(
@@ -970,6 +977,7 @@ class PlainTextInputElement(InputInteractiveElement):
         multiline: Optional[bool] = None,
         min_length: Optional[int] = None,
         max_length: Optional[int] = None,
+        dispatch_action_config: Optional[Union[dict, DispatchActionConfig]] = None,
         **others: dict,
     ):
         """
@@ -989,6 +997,7 @@ class PlainTextInputElement(InputInteractiveElement):
         self.multiline = multiline
         self.min_length = min_length
         self.max_length = max_length
+        self.dispatch_action_config = dispatch_action_config
 
 
 # -------------------------------------------------

--- a/slack_sdk/models/blocks/blocks.py
+++ b/slack_sdk/models/blocks/blocks.py
@@ -283,7 +283,9 @@ class InputBlock(Block):
 
     @property
     def attributes(self) -> Set[str]:
-        return super().attributes.union({"label", "hint", "element", "optional"})
+        return super().attributes.union(
+            {"label", "hint", "element", "optional", "dispatch_action"}
+        )
 
     def __init__(
         self,
@@ -292,6 +294,7 @@ class InputBlock(Block):
         element: Union[str, dict, InputInteractiveElement],
         block_id: Optional[str] = None,
         hint: Optional[Union[str, dict, PlainTextObject]] = None,
+        dispatch_action: Optional[bool] = None,
         optional: Optional[bool] = None,
         **others: dict,
     ):
@@ -306,6 +309,7 @@ class InputBlock(Block):
         self.label = TextObject.parse(label, default_type=PlainTextObject.type)
         self.element = BlockElement.parse(element)
         self.hint = TextObject.parse(hint, default_type=PlainTextObject.type)
+        self.dispatch_action = dispatch_action
         self.optional = optional
 
     @JsonValidator(f"label attribute cannot exceed {label_max_length} characters")

--- a/tests/slack_sdk/web/classes/test_blocks.py
+++ b/tests/slack_sdk/web/classes/test_blocks.py
@@ -545,6 +545,19 @@ class InputBlockTests(unittest.TestCase):
                 "label": {"type": "plain_text", "text": "Label", "emoji": True,},
                 "hint": {"type": "plain_text", "text": "some hint", "emoji": True,},
             },
+            {
+                "dispatch_action": True,
+                "type": "input",
+                "element": {
+                    "type": "plain_text_input",
+                    "action_id": "plain_text_input-action"
+                },
+                "label": {
+                    "type": "plain_text",
+                    "text": "Label",
+                    "emoji": True
+                }
+            }
         ]
         for input in blocks:
             self.assertDictEqual(input, InputBlock(**input).to_dict())

--- a/tests/slack_sdk/web/classes/test_elements.py
+++ b/tests/slack_sdk/web/classes/test_elements.py
@@ -685,6 +685,15 @@ class PlainTextInputElementTests(unittest.TestCase):
         }
         self.assertDictEqual(input, PlainTextInputElement(**input).to_dict())
 
+    def test_document_3(self):
+        input = {
+            "type": "plain_text_input",
+            "multiline": True,
+            "dispatch_action_config": {
+              "trigger_actions_on": ["on_character_entered"]
+            }
+        }
+        self.assertDictEqual(input, PlainTextInputElement(**input).to_dict())
 
 # -------------------------------------------------
 # Radio Buttons


### PR DESCRIPTION
## Summary

This pull request adds the new features described in #841 to the v3 branch.

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack.web.WebClient** (Web API client)
- [ ] **slack.webhook.WebhookClient** (Incoming Webhook, response_url sender)
- [x] **slack.web.classes** (UI component builders)
- [ ] **slack.rtm.RTMClient** (RTM client)
- [ ] Documents
- [ ] Others

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes.
