### PR TITLE
Add Dispatch Action in Block Kit #841

### DIFF
--- a/slack/web/classes/blocks.py
+++ b/slack/web/classes/blocks.py
@@ -280,7 +280,9 @@ class InputBlock(Block):
 
     @property
     def attributes(self) -> Set[str]:
-        return super().attributes.union({"label", "hint", "element", "optional"})
+        return super().attributes.union(
+            {"label", "hint", "element", "optional", "dispatch_action"}
+        )
 
     def __init__(
         self,
@@ -290,6 +292,7 @@ class InputBlock(Block):
         block_id: Optional[str] = None,
         hint: Optional[Union[str, dict, PlainTextObject]] = None,
         optional: Optional[bool] = None,
+        dispatch_action: Optional[bool] = None,
         **others: dict,
     ):
         """A block that collects information from users - it can hold a plain-text input element,
@@ -304,6 +307,7 @@ class InputBlock(Block):
         self.element = BlockElement.parse(element)
         self.hint = TextObject.parse(hint, default_type=PlainTextObject.type)
         self.optional = optional
+        self.dispatch_action = dispatch_action
 
     @JsonValidator(f"label attribute cannot exceed {label_max_length} characters")
     def _validate_label_length(self):

--- a/slack/web/classes/elements.py
+++ b/slack/web/classes/elements.py
@@ -9,6 +9,7 @@ from . import EnumValidator, JsonObject, JsonValidator, show_unknown_key_warning
 from .objects import (
     ButtonStyles,
     ConfirmObject,
+    DispatchActionConfig,
     Option,
     OptionGroup,
     TextObject,
@@ -956,7 +957,13 @@ class PlainTextInputElement(InputInteractiveElement):
     @property
     def attributes(self) -> Set[str]:
         return super().attributes.union(
-            {"initial_value", "multiline", "min_length", "max_length"}
+            {
+                "initial_value",
+                "multiline",
+                "min_length",
+                "max_length",
+                "dispatch_action_config",
+            }
         )
 
     def __init__(
@@ -969,6 +976,7 @@ class PlainTextInputElement(InputInteractiveElement):
         multiline: Optional[bool] = None,
         min_length: Optional[int] = None,
         max_length: Optional[int] = None,
+        dispatch_action_config: Optional[Union[dict, DispatchActionConfig]] = None,
         **others: dict,
     ):
         """
@@ -988,6 +996,7 @@ class PlainTextInputElement(InputInteractiveElement):
         self.multiline = multiline
         self.min_length = min_length
         self.max_length = max_length
+        self.dispatch_action_config = dispatch_action_config
 
 
 # -------------------------------------------------

--- a/slack/web/classes/objects.py
+++ b/slack/web/classes/objects.py
@@ -540,3 +540,35 @@ class OptionGroup(JsonObject):
                 "label": dict_label,
                 "options": dict_options,
             }
+
+
+class DispatchActionConfig(JsonObject):
+    attributes = {"trigger_actions_on"}
+
+    @classmethod
+    def parse(cls, config: Union["DispatchActionConfig", dict]):
+        if config:
+            if isinstance(config, DispatchActionConfig):  # skipcq: PYL-R1705
+                return config
+            elif isinstance(config, dict):
+                return DispatchActionConfig(**config)
+            else:
+                # Not yet implemented: show some warning here
+                return None
+        return None
+
+    def __init__(
+        self, *, trigger_actions_on: Optional[list] = None,
+    ):
+        """
+        Determines when a plain-text input element will return a block_actions interaction payload.
+        https://api.slack.com/reference/block-kit/composition-objects#dispatch_action_config
+        """
+        self._trigger_actions_on = trigger_actions_on or []
+
+    def to_dict(self) -> dict:  # skipcq: PYL-W0221
+        self.validate_json()
+        json = {}
+        if self._trigger_actions_on:
+            json["trigger_actions_on"] = self._trigger_actions_on
+        return json

--- a/tests/web/classes/test_blocks.py
+++ b/tests/web/classes/test_blocks.py
@@ -607,6 +607,19 @@ class InputBlockTests(unittest.TestCase):
                     "emoji": True,
                 },
             },
+            {
+                "dispatch_action": True,
+                "type": "input",
+                "element": {
+                    "type": "plain_text_input",
+                    "action_id": "plain_text_input-action"
+                },
+                "label": {
+                    "type": "plain_text",
+                    "text": "Label",
+                    "emoji": True
+                }
+            }
         ]
         for input in blocks:
             self.assertDictEqual(input, InputBlock(**input).to_dict())

--- a/tests/web/classes/test_elements.py
+++ b/tests/web/classes/test_elements.py
@@ -803,6 +803,16 @@ class PlainTextInputElementTests(unittest.TestCase):
         }
         self.assertDictEqual(input, PlainTextInputElement(**input).to_dict())
 
+    def test_document_3(self):
+        input = {
+            "type": "plain_text_input",
+            "multiline": True,
+            "dispatch_action_config": {
+                "trigger_actions_on": ["on_character_entered"]
+            }
+        }
+        self.assertDictEqual(input, PlainTextInputElement(**input).to_dict())
+
 
 # -------------------------------------------------
 # Radio Buttons


### PR DESCRIPTION
## Summary

This pull request adds the feature described in #841 to 2.9 series.

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack.web.WebClient** (Web API client)
- [ ] **slack.webhook.WebhookClient** (Incoming Webhook, response_url sender)
- [x] **slack.web.classes** (UI component builders)
- [ ] **slack.rtm.RTMClient** (RTM client)
- [ ] Documents
- [ ] Others

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes.
