### PR TITLE
Fix #846 RTMClient does not pass timeout value to WebClient

### DIFF
--- a/slack/rtm/client.py
+++ b/slack/rtm/client.py
@@ -136,6 +136,7 @@ class RTMClient:
         self._web_client = WebClient(
             token=self.token,
             base_url=self.base_url,
+            timeout=self.timeout,
             ssl=self.ssl,
             proxy=self.proxy,
             run_async=self.run_async,
@@ -530,6 +531,7 @@ class RTMClient:
             self._web_client = WebClient(
                 token=self.token,
                 base_url=self.base_url,
+                timeout=self.timeout,
                 ssl=self.ssl,
                 proxy=self.proxy,
                 run_async=True,


### PR DESCRIPTION
## Summary

This pull request fixes #846 

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack.web.WebClient** (Web API client)
- [ ] **slack.webhook.WebhookClient** (Incoming Webhook, response_url sender)
- [ ] **slack.web.classes** (UI component builders)
- [x] **slack.rtm.RTMClient** (RTM client)
- [ ] Documents
- [ ] Others

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes.
